### PR TITLE
[HOY-23]fix: 홈, 프로필 아이템 카드 QA 수정사항 반영(김인)

### DIFF
--- a/src/shared/components/HomeItemCard.tsx
+++ b/src/shared/components/HomeItemCard.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import { Star } from 'lucide-react';
 import React from 'react';
 
+import SafeImage from '@/shared/components/SafeImage';
+
 /* props 사용 설명입니다.
  * title: 콘텐츠 제목
  * contentImage: api상 이미지
@@ -44,9 +46,9 @@ const HomeItemCard = ({
     <Link href={`/product/${contentId}`} className={CARD_BASE_STYLE}>
       {/* 아이템 요소 컨테이너 */}
       <div className='flex w-full flex-col gap-[10px]'>
-        {/* 이미지 컨테이너 - api 이미지 비율이 다를 경우 깨질 수 있어 고정 값 대신 해당 사항 적용*/}
-        <div className='relative aspect-[14/9] w-full'>
-          <Image src={contentImage} alt={title} fill className='object-cover' />
+        {/* 이미지 컨테이너 - api 이미지 비율이 다를 경우 깨질 수 있어 고정 값 대신 해당 사항 적용 + 최소 너비 min-w 추가 */}
+        <div className='relative aspect-[14/9] w-full min-w-[140px]'>
+          <SafeImage src={contentImage} alt={title} fill className='object-cover' />
         </div>
         {/* 제목 및 값 섹션 */}
         <div className='w-full'>

--- a/src/shared/components/SafeImage.tsx
+++ b/src/shared/components/SafeImage.tsx
@@ -1,0 +1,27 @@
+//아이템 카드 폴백 이미지 처리용 컴포넌트
+'use client';
+
+import Image, { ImageProps } from 'next/image';
+
+import { useState } from 'react';
+
+const fallbackImage = '/images/fallbackImage.png';
+
+type Props = ImageProps;
+
+const SafeImage = ({ src, alt, ...props }: Props) => {
+  const [errored, setError] = useState(false);
+  const isFallback = !src || errored;
+
+  return (
+    <Image
+      {...props}
+      src={errored ? fallbackImage : src}
+      alt={alt}
+      onError={() => setError(true)}
+      className={isFallback ? 'bg-black-800 object-contain p-4' : 'object-cover'}
+    />
+  );
+};
+
+export default SafeImage;


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->
![아이템카드 수정 시연](https://github.com/user-attachments/assets/6347f988-8eec-4062-aca1-5958010e37ef)

- min-w-[140px]을 적용하여 컨텐츠 너비가 너무 작아지는 것을 방지하도록 수정했습니다.
- fallback 이미지(상의 후 디자인 확정) 처리를 해주는 SafeImage 컴포넌트를 추가하여 이미지 없음(null/빈 문자열), 잘못된 이미지 URl, 이미지 URL 존재하지만 404/깨짐 상황에서 fallback 이미지로 대체하도록 했습니다.

## ✏️ 작업 내용 (📷 스크린샷•동영상)

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위
src/shared/components/HomeItemCard.tsx: 이미지 부분 디자인 값 수정, SafeImage 컴포넌트를 사용하도록 수정
src/shared/components/SafeImage.tsx: fallback 이미지 처리용 컴포넌트 추가
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
