### PR TITLE
[HOY-102] fix: 공용 버튼 호버 색상 추가, 회원가입 페이지 모바일 뷰 버튼 여백 조정 (윤정환)

### DIFF
--- a/src/features/auth/signUp/components/SignUpForm.tsx
+++ b/src/features/auth/signUp/components/SignUpForm.tsx
@@ -87,7 +87,7 @@ const SignUpForm = () => {
         {...register('passwordConfirmation')}
       />
       <Button
-        className='mt-[126px] max-w-full md:mt-5'
+        className='mt-15 max-w-full md:mt-5'
         type='submit'
         disabled={isSubmitting || !isValid}
       >

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -6,17 +6,6 @@ interface Props extends ComponentPropsWithoutRef<'button'> {
   variant?: 'primary' | 'secondary' | 'tertiary';
 }
 
-const VARIANT_STYLE = {
-  primary:
-    'transition-all ease-in-out duration-200 bg-main text-white disabled:bg-black-700 disabled:text-gray-600 hover:bg-red',
-  secondary: 'bg-transparent text-main border-1 border-main hover:border-red hover:text-red',
-  tertiary:
-    'bg-transparent text-gray-600 border-1 border-gray-600 hover:border-gray-400 hover:text-gray-400 focus:border-red focus:text-red',
-};
-
-const BASE_STYLE =
-  'xl:text-lg-semibold flex h-[50px] w-full max-w-[335px] cursor-pointer items-center justify-center rounded-md font-semibold whitespace-nowrap disabled:cursor-auto md:h-[55px] md:max-w-110 xl:h-[65px] xl:max-w-160';
-
 const Button = ({ className, type = 'button', variant = 'primary', ...props }: Props) => {
   return (
     <button className={cn(BASE_STYLE, VARIANT_STYLE[variant], className)} type={type} {...props}>
@@ -26,3 +15,15 @@ const Button = ({ className, type = 'button', variant = 'primary', ...props }: P
 };
 
 export default Button;
+
+const VARIANT_STYLE = {
+  primary:
+    'transition-all ease-in-out duration-200 bg-main text-white disabled:bg-black-700 disabled:text-gray-600 hover:bg-red',
+  secondary:
+    'bg-transparent text-main border-1 border-main hover:border-red hover:text-red hover:bg-red/10',
+  tertiary:
+    'bg-transparent text-gray-600 border-1 border-gray-600 hover:border-gray-400 hover:text-gray-400 hover:bg-gray-400/10 focus:border-red focus:text-red focus:hover:bg-red/10',
+};
+
+const BASE_STYLE =
+  'xl:text-lg-semibold flex h-[50px] w-full max-w-[335px] cursor-pointer items-center justify-center rounded-md font-semibold whitespace-nowrap disabled:cursor-auto md:h-[55px] md:max-w-110 xl:h-[65px] xl:max-w-160';


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)
## 버튼
붉은 테두리 버튼 -> red, opacity-10%로 호버 색상 넣어줬습니다.
회색 테두리 버튼 -> 선택이 안된 상태에서는 gray-400. opacity-10%, 선택이 된 상태에서는 red, opacity-10%로 호버 색상 넣어줬습니다.
수정하는김에 스타일 상수들을 컴포넌트 뒤로 이동시켰습니다.

**Before**

https://github.com/user-attachments/assets/c4436a34-325f-4305-831e-f0ca166c22f2


**After**

https://github.com/user-attachments/assets/8cc8cdd9-dcc9-4766-9a5b-282a66d21ed8

## 회원가입
기존 간격 156px에서 90px로 좁혔습니다.

**Before**
<img width="302" height="604" alt="스크린샷 2025-08-27 011928" src="https://github.com/user-attachments/assets/e9b3b1bc-80c0-4aa9-ac56-b99c056aeaff" />

**After**
<img width="308" height="578" alt="스크린샷 2025-08-27 012021" src="https://github.com/user-attachments/assets/31f5facc-9330-42de-a057-4b6ce9bd2b30" />

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위

outline 버튼을 사용하는 컴포넌트, 회원가입 페이지

## ✅ 체크리스트

- [ ] pr요청시 lint + 빌드를 통과했습니다.
- [ ] 코드가 스타일 가이드를 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 복잡/핵심 로직에 주석을 추가했습니다.
- [ ] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

이메일 '특수문자 사용 불가' 에러 메시지 처리는 수정 대상에서 제외했습니다.
1. 원래 피드백 의도대로 '단순히 메일 형식이 아닌 것'과 '특수 문자를 사용한 것'의 케이스를 분리하려고 해봤는데, zod를 사용하게되면 메일 형식체크를 먼저하고, 특수문자가 사용되었는지 여부를 이후 refine 구문에서 추가로 하게 됩니다. 그런데 이미 형식체크가 특수문자를 사용한 경우를 모두 포함하고있는 검사이기 때문에, 따로 분리를 해주어도 '메일 형식이 아닙니다'에서 에러가 전부 필터링되어 '특수 문자 사용 불가' 메시지가 출력될 수 있는 경우가 없습니다.
2. 따라서 대안으로 기존 이메일 형식으로 작성해주세요 문구에 (특수문자 사용 불가)까지 추가하는 것도 생각해봤는데, 원래 의도가 분기처리에 의한 정확한 피드백이었던 만큼, 위 처럼 수정하게되면 특수문자를 사용하지 않았는데도 다른 에러 케이스에서도 (특수문자 사용 불가능) 문구가 나오는 것이 오히려 사용자를 헷갈리게 할 수 있는 요소라고 생각되어 기존의 에러 텍스트를 유지하는 것이 낫다고 생각했습니다.
