### PR TITLE
[HOY-102] feat: 로그인 페이지 폼 연동 및 api 연결 (윤정환)

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,13 +1,24 @@
 import { publicApiClient } from '@/shared/api/apiClients';
 
-import { SignUpFormValues, SignUpResponse } from '../types/authTypes';
+import { SignInSchema, SignUpSchema } from '../schemas/authSchema';
+import { AuthResponse } from '../types/authTypes';
 
-export const signUpRequest = async (data: SignUpFormValues): Promise<SignUpResponse> => {
+export const signUpRequest = async (data: SignUpSchema): Promise<AuthResponse> => {
   try {
     const res = await publicApiClient.post('/auth/signUp', data);
     return res.data;
   } catch (e) {
     console.log('회원가입 요청 에러');
+    throw e;
+  }
+};
+
+export const signInRequest = async (data: SignInSchema): Promise<AuthResponse> => {
+  try {
+    const res = await publicApiClient.post('/auth/signin', data);
+    return res.data;
+  } catch (e) {
+    console.log('로그인 요청 에러');
     throw e;
   }
 };

--- a/src/features/auth/schemas/authSchema.ts
+++ b/src/features/auth/schemas/authSchema.ts
@@ -3,8 +3,10 @@ import z from 'zod';
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const PASSWORD_REGEX = /^[a-zA-Z0-9!@#$%^&*]+$/;
 //모든 항목이 필수이기 때문에 중복되는 규칙인 필수값 규칙을 기본으로 세팅, 제출될 때 trim처리
-const requiredString = z.string().trim().min(1, { message: '필수 입력 항목입니다.' });
+const trimmedString = z.string().trim();
+const requiredString = trimmedString.min(1, { message: '필수 입력 항목입니다.' });
 
+//SignUp
 export const signUpSchema = z
   .object({
     email: requiredString.regex(EMAIL_REGEX, { message: '이메일 형식으로 작성해 주세요.' }),
@@ -22,3 +24,11 @@ export const signUpSchema = z
 
 //z.infer -> 스키마로부터 typescript 타입 자동 추론
 export type SignUpSchema = z.infer<typeof signUpSchema>;
+
+//SignIn
+export const signInSchema = z.object({
+  email: trimmedString,
+  password: trimmedString,
+});
+
+export type SignInSchema = z.infer<typeof signInSchema>;

--- a/src/features/auth/signIn/components/SignInForm.tsx
+++ b/src/features/auth/signIn/components/SignInForm.tsx
@@ -1,27 +1,88 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import axios from 'axios';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
 import Button from '@/shared/components/Button';
 import Input from '@/shared/components/Input';
 import PasswordInput from '@/shared/components/PasswordInput';
 
+import { signInRequest } from '../../api/authApi';
+import { SignInSchema, signInSchema } from '../../schemas/authSchema';
+
 const SignInForm = () => {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    resolver: zodResolver(signInSchema),
+    reValidateMode: 'onChange',
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+  const router = useRouter();
+
+  const onSubmit: SubmitHandler<SignInSchema> = async (data) => {
+    try {
+      const res = await signInRequest(data);
+      console.log(res);
+      // 토큰이랑 user.me 요청 로직 이후 추가
+      router.push('/');
+    } catch (e) {
+      if (axios.isAxiosError(e)) {
+        const message = e.response?.data.message;
+        const status = e.status;
+        //status 400에러 -> 유효성 검사 실패 -> 필드 에러 메시지 처리
+        if (status === 400 && message.includes('이메일')) {
+          setError('email', { type: 'server', message: message });
+        } else if (status === 400 && message.includes('비밀번호')) {
+          setError('password', { type: 'server', message: message });
+        } else if (status === 400) {
+          setError('email', { type: 'server', message: '이메일 또는 비밀번호를 다시 확인하세요.' });
+          setError('password', {
+            type: 'server',
+            message: '이메일 또는 비밀번호를 다시 확인하세요.',
+          });
+        } else {
+          // status 400 이외 에러 -> 네트워크 등 문제 -> 토스트로 처리
+          console.log(message, status); //추후에 토스트 출력 '알 수 없는 에러가 발생했습니다. 다시 시도하세요'
+        }
+      }
+    }
+  };
+
   return (
-    <form className='mx-auto flex flex-col gap-[30px] md:w-110 md:gap-10 xl:w-160'>
+    <form
+      className='mx-auto flex flex-col gap-[30px] md:w-110 md:gap-10 xl:w-160'
+      onSubmit={handleSubmit(onSubmit)}
+      noValidate
+    >
       <Input
         label='이메일'
         id='email'
         type='email'
         autoComplete='email'
         placeholder='이메일을 입력해 주세요'
+        error={errors.email}
+        {...register('email')}
       />
       <PasswordInput
         label='비밀번호'
         id='password'
         placeholder='비밀번호를 입력해 주세요'
         autoComplete='current-password'
+        error={errors.password}
+        {...register('password')}
       />
-      <Button className='mt-[30px] max-w-full md:mt-5' type='submit'>
-        로그인
+      <Button className='mt-[30px] max-w-full md:mt-5' type='submit' disabled={isSubmitting}>
+        {isSubmitting ? '요청 대기중...' : '로그인'}
       </Button>
     </form>
   );

--- a/src/features/auth/types/authTypes.ts
+++ b/src/features/auth/types/authTypes.ts
@@ -8,14 +8,7 @@ interface BaseUserType {
   teamId: '16-7';
 }
 
-export interface SignUpResponse {
+export interface AuthResponse {
   accessToken: string;
   user: BaseUserType & { email: string };
-}
-
-export interface SignUpFormValues {
-  email: string;
-  nickname: string;
-  password: string;
-  passwordConfirmation: string;
 }


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

로그인 페이지 폼 연동 및 api 연결했습니다.
구조는 회원가입 페이지와 크게 다르지 않습니다.

https://github.com/user-attachments/assets/e6dcd798-4ac0-4198-943a-d86bb0dae9d0

단, 유효성 검사 전략은 사용해본 사이트 경험과, 네이버 로그인, 회원가입 페이지를 참고해서 두 페이지의 전략을 다르게 가져갔습니다.

- 회원가입 - 사용자가 사이트를 이용하면서 한 번 이상 사용하지 않을 확률이 높기 때문에 모든 필드에 대해 onBlur시에 유효성 검사를 하여 상대적으로 엄격한 검사를 진행
- 로그인 - 사용자가 자주 실행하는 기능이기 때문에 너무 잦은 유효성 검사는 사용자를 피로하게 만든다고 생각. 따라서 버튼을 항상 활성화하고 유효성 검사도 onBlur가 아닌 onSubmit일 때만 모든 필드를 통합해서 진행

더 세부적인 에러 메시지 분기 처리는 아래와 같습니다.
1. 형식에 맞지 않는 이메일과 비밀번호 제출시 -> '이메일 또는 비밀번호를 다시 확인해주세요.'
2. 둘 다 형식은 맞으나 존재하지 않는 이메일 제출시 -> '존재하지 않는 이메일입니다.'
3. 둘다 형식은 맞으나 비밀번호가 일치하지 않을시 -> '비밀번호가 일치하지 않습니다.'

추가로 관련 auth 타입이나 api, 스키마를 수정했습니다.

## 📌 변경 범위

로그인 페이지

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
