### PR TITLE
[HOY-120] feat: fetch api 인스턴스 제작 (윤정환)

### DIFF
--- a/src/shared/api/apiClients.ts
+++ b/src/shared/api/apiClients.ts
@@ -1,9 +1,11 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import Cookies from 'js-cookie';
 
+import { BASE_URL } from '../constants/constants';
+
 // 인증 토큰을 요구하지 않는 api 요청 instance
 export const publicApiClient: AxiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  baseURL: BASE_URL,
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
@@ -11,7 +13,7 @@ export const publicApiClient: AxiosInstance = axios.create({
 });
 
 export const privateApiClient: AxiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  baseURL: BASE_URL,
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',

--- a/src/shared/api/serverApi.ts
+++ b/src/shared/api/serverApi.ts
@@ -8,22 +8,18 @@ const serverFetch = async (endpoint: string, options?: RequestInit) => {
   const headers = new Headers(options?.headers);
   headers.set('Content-Type', 'application/json');
 
-  console.log('여기');
   if (accessToken) {
     headers.set('Authorization', `Bearer ${accessToken}`);
   }
-  console.log('여기');
 
   const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}${endpoint}`, {
     ...options,
     headers,
   });
-  console.log('여기');
 
   if (!response.ok) {
     throw new Error('Fetch API 요청 실패');
   }
-  console.log('여기');
 
   return response.json();
 };

--- a/src/shared/api/serverApi.ts
+++ b/src/shared/api/serverApi.ts
@@ -1,5 +1,7 @@
 import { cookies } from 'next/headers';
 
+import { BASE_URL } from '../constants/constants';
+
 //fetch api 헤더에 토큰부여
 const serverFetch = async (endpoint: string, options?: RequestInit) => {
   const accessToken = (await cookies()).get('accessToken')?.value;
@@ -12,13 +14,18 @@ const serverFetch = async (endpoint: string, options?: RequestInit) => {
     headers.set('Authorization', `Bearer ${accessToken}`);
   }
 
-  const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}${endpoint}`, {
+  if (!BASE_URL) {
+    throw new Error('환경 변수 NEXT_PUBLIC_BASE_URL이 설정되지 않았습니다.');
+  }
+
+  const response = await fetch(`${BASE_URL}${endpoint}`, {
     ...options,
     headers,
   });
 
   if (!response.ok) {
-    throw new Error('Fetch API 요청 실패');
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Fetch 실패: ${response.status} ${response.statusText} ${errorText}`);
   }
 
   return response.json();

--- a/src/shared/api/serverApi.ts
+++ b/src/shared/api/serverApi.ts
@@ -1,0 +1,61 @@
+import { cookies } from 'next/headers';
+
+//fetch api 헤더에 토큰부여
+const serverFetch = async (endpoint: string, options?: RequestInit) => {
+  const accessToken = (await cookies()).get('accessToken')?.value;
+
+  //option에 header key가 있다면 추가
+  const headers = new Headers(options?.headers);
+  headers.set('Content-Type', 'application/json');
+
+  console.log('여기');
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+  console.log('여기');
+
+  const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}${endpoint}`, {
+    ...options,
+    headers,
+  });
+  console.log('여기');
+
+  if (!response.ok) {
+    throw new Error('Fetch API 요청 실패');
+  }
+  console.log('여기');
+
+  return response.json();
+};
+
+//토큰부여 함수를 호출하는 fetch api instance
+const serverApi = {
+  get: (endpoint: string, options?: RequestInit) => {
+    return serverFetch(endpoint, {
+      method: 'GET',
+      ...options,
+    });
+  },
+  post: <T>(endpoint: string, body: T, options?: RequestInit) => {
+    return serverFetch(endpoint, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      ...options,
+    });
+  },
+  patch: <T>(endpoint: string, body: T, options?: RequestInit) => {
+    return serverFetch(endpoint, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+      ...options,
+    });
+  },
+  delete: (endpoint: string, options?: RequestInit) => {
+    return serverFetch(endpoint, {
+      method: 'DELETE',
+      ...options,
+    });
+  },
+};
+
+export default serverApi;

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -14,3 +14,6 @@ export const CATEGORIES: Category[] = [
   { id: '6', name: '키즈', value: 'KIDS' },
   { id: '7', name: '예능', value: 'ENTERTAINMENT' },
 ];
+
+// api url/key
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->
next/header의 cookies를 사용해서 서버에서 동작하는 fetch api에 토큰을 추가하는 인스턴스를 제작했습니다.

shared/api/serverApi에 **serverApi** 인스턴스를 활용하시면 됩니다.
서버 컴포넌트에서는 주로 get 메서드만 쓰일 것 같으나, 서버 액션 활용 계획이 있으신지 모르기 때문에 일단 post, patch, delete에 대해서도 정의했습니다.

## 사용방법
인증이 필요한 유일한 get 요청인 users/me를 예시로 들겠습니다. (화면에 렌더링할 용도가 아니라면 users/me get 요청도 이미 UserStore로 관리되고 있기 때문에 아마 쓰일 상황은 별로 없을 것 같습니다.)
```tsx
const getMeByServer = async () => {
  try {
    const data = await serverApi.get('/users/me');
    return data;
  } catch (e) {
  ...
  }
}
```

## 📌 변경 범위

<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
원래 서버 컴포넌트에서 get요청에 토큰을 넣어주려는 용도로 만들었는데, 이번 프로젝트 user/me를 제외한 모든 get 요청에 인증이 필요없다는 사실을 알고 사실 해당 인스턴스가 사용될지는 잘 모르겠습니다.
클라이언트 컴포넌트쪽에서는 post, patch, delete 요청은 아마 axios쪽이 쓰일 가능성이 더 높으니, 만약 serverApi의 해당 메서드들이 쓰인다면 서버 액션쪽 밖에 없을 것 같아서 서버 액션을 사용하신다면 그 때 사용하시면 될 것 같습니다.