### PR TITLE
[HOY-103] feat: 카카오 소셜 로그인 기능 구현 (윤정환)

### DIFF
--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -7,15 +7,20 @@ import { useEffect, useState } from 'react';
 
 import { kakaoSignInRequest } from '@/features/auth/api/authApi';
 import KakaoError from '@/features/auth/components/KakaoError';
+import { setCookie } from '@/features/auth/utils/cookie';
+import moveToKakao from '@/features/auth/utils/moveToKakao';
+import LoadingImage from '@/shared/components/LoadingImage';
+import { useUserStore } from '@/shared/stores/userStore';
 
 const KakaoCallbackPage = () => {
+  const setUser = useUserStore((state) => state.setUser);
   const [hasError, setHasError] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
 
   useEffect(() => {
     const code = searchParams.get('code');
-    const state = searchParams.get('state');
+    // const state = searchParams.get('state'); 이후 리다이렉트 로직에서 처리
     const kakaoError = searchParams.get('error');
 
     if (kakaoError) {
@@ -23,7 +28,6 @@ const KakaoCallbackPage = () => {
       return;
     }
 
-    //회원가입 된 유저인지 확인
     if (code) {
       const kakaoLogin = async () => {
         try {
@@ -31,24 +35,38 @@ const KakaoCallbackPage = () => {
             redirectUri: `${window.location.origin}/oauth/kakao`,
             token: code,
           });
-          console.log(res);
+          const { accessToken } = res;
+
+          if (accessToken) {
+            setCookie('accessToken', accessToken);
+          }
+
+          setUser();
+          console.log(res.user?.nickname, '님 환영합니다'); //토스트 로그인 처리
+          router.replace('/');
         } catch (e) {
           console.log(e);
-          if (isAxiosError(e) && e.status === 404) {
-            console.log('여기');
-            router.replace(`/oauth/signup/kakao?code=${code}`);
-          }
+          if (isAxiosError(e) && e.status === 403) {
+            //회원가입 된 유저인지 확인, 아니라면 회원가입으로 이동
+            moveToKakao('/oauth/signup/kakao');
+          } else if (isAxiosError(e) && e.status === 400)
+            //잘못된 인가 코드
+            setHasError(true);
           throw e;
         }
       };
 
       kakaoLogin();
     }
-  }, [searchParams, router]);
+  }, []);
 
   if (hasError) return <KakaoError />;
 
-  return <p className='text-white'>카카오 로그인 처리중...</p>;
+  return (
+    <div className='flex h-dvh items-center justify-center'>
+      <LoadingImage loadingText='간편 로그인 처리중...' />
+    </div>
+  );
 };
 
 export default KakaoCallbackPage;

--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -28,7 +28,9 @@ const KakaoCallbackPage = () => {
       return;
     }
 
-    if (code) {
+    if (!code) {
+      setHasError(true);
+    } else {
       const kakaoLogin = async () => {
         try {
           const res = await kakaoSignInRequest({

--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { isAxiosError } from 'axios';
+import { useEffect, useState } from 'react';
+
+import { kakaoSignInRequest } from '@/features/auth/api/authApi';
+import KakaoError from '@/features/auth/components/KakaoError';
+
+const KakaoCallbackPage = () => {
+  const [hasError, setHasError] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const kakaoError = searchParams.get('error');
+
+    if (kakaoError) {
+      setHasError(true);
+      return;
+    }
+
+    //회원가입 된 유저인지 확인
+    if (code) {
+      const kakaoLogin = async () => {
+        try {
+          const res = await kakaoSignInRequest({
+            redirectUri: `${window.location.origin}/oauth/kakao`,
+            token: code,
+          });
+          console.log(res);
+        } catch (e) {
+          console.log(e);
+          if (isAxiosError(e) && e.status === 404) {
+            console.log('여기');
+            router.replace(`/oauth/signup/kakao?code=${code}`);
+          }
+          throw e;
+        }
+      };
+
+      kakaoLogin();
+    }
+  }, [searchParams, router]);
+
+  if (hasError) return <KakaoError />;
+
+  return <p className='text-white'>카카오 로그인 처리중...</p>;
+};
+
+export default KakaoCallbackPage;

--- a/src/app/oauth/signup/kakao/page.tsx
+++ b/src/app/oauth/signup/kakao/page.tsx
@@ -1,5 +1,22 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+import KakaoError from '@/features/auth/components/KakaoError';
+import KakaoSignUpForm from '@/features/auth/oauth/components/KakaoSignUpForm';
+
 const KakaoSignUpPage = () => {
-  return <></>;
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
+
+  //로그인 플로우를 통해 접근하지 않고 직접 url입력 접근 등의 경우 차단
+  if (!code) return <KakaoError />;
+
+  return (
+    <section>
+      <KakaoSignUpForm kakaoCode={code} />
+    </section>
+  );
 };
 
 export default KakaoSignUpPage;

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -2,7 +2,7 @@ import { privateApiClient, publicApiClient } from '@/shared/api/apiClients';
 import { DetailUser } from '@/shared/types/userTypes';
 
 import { SignInSchema, SignUpSchema } from '../schemas/authSchema';
-import { AuthResponse } from '../types/authTypes';
+import { AuthResponse, KakaoLoginData, KakaoSignUpData } from '../types/authTypes';
 
 export const signUpRequest = async (data: SignUpSchema): Promise<AuthResponse> => {
   try {
@@ -30,6 +30,26 @@ export const getMe = async (): Promise<DetailUser> => {
     return res.data;
   } catch (e) {
     console.log('사용자 정보 요청 에러');
+    throw e;
+  }
+};
+
+export const kakaoSignInRequest = async (data: KakaoLoginData): Promise<AuthResponse> => {
+  try {
+    const res = await publicApiClient.post('/auth/signIn/kakao', data);
+    return res.data;
+  } catch (e) {
+    console.log('카카오 로그인 요청 에러');
+    throw e;
+  }
+};
+
+export const kakaoSignUpRequest = async (data: KakaoSignUpData): Promise<AuthResponse> => {
+  try {
+    const res = await publicApiClient.post('/auth/signUp/kakao', data);
+    return res.data;
+  } catch (e) {
+    console.log('카카오 가편 회원가입 요청 에러');
     throw e;
   }
 };

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -49,7 +49,7 @@ export const kakaoSignUpRequest = async (data: KakaoSignUpData): Promise<AuthRes
     const res = await publicApiClient.post('/auth/signUp/kakao', data);
     return res.data;
   } catch (e) {
-    console.log('카카오 가편 회원가입 요청 에러');
+    console.log('카카오 간편 회원가입 요청 에러');
     throw e;
   }
 };

--- a/src/features/auth/components/AuthGuard.tsx
+++ b/src/features/auth/components/AuthGuard.tsx
@@ -9,9 +9,7 @@ import LoadingImage from '@/shared/components/LoadingImage';
 import { useUserStore } from '@/shared/stores/userStore';
 
 //로그인 되었을 때 접근 방지할 경로
-const AUTH_ROUTES = ['/signin', '/signup', '/oauth/signup/kakao'];
-
-//로그인 되지 않았을 때 접근 가능한 경로
+const AUTH_ROUTES = ['/signin', '/signup', '/oauth/kakao', '/oauth/signup/kakao'];
 
 interface Props {
   children: ReactNode;
@@ -51,8 +49,8 @@ const AuthGuard = ({ children }: Props) => {
 
   if (!isMounted || (isLoggedIn && isAuthPath)) {
     return (
-      <div className='pt-80 md:pt-120 xl:pt-80'>
-        <LoadingImage />
+      <div className='flex h-dvh items-center justify-center'>
+        <LoadingImage loadingText='Loading...' />
       </div>
     );
   }

--- a/src/features/auth/components/KakaoError.tsx
+++ b/src/features/auth/components/KakaoError.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+import Button from '@/shared/components/Button';
+
+const KakaoError = () => {
+  return (
+    <div className='flex flex-col items-center gap-20 px-5 pt-64 md:gap-30 md:pt-96 xl:gap-35 xl:pt-80'>
+      <p className='text-xl-semibold xl:text-2xl-semibold text-white'>비정상적인 접근입니다.</p>
+      <Link className='w-full md:w-110 xl:w-160' href='/'>
+        <Button className='max-w-none' variant='primary'>
+          홈으로 가기
+        </Button>
+      </Link>
+    </div>
+  );
+};
+
+export default KakaoError;

--- a/src/features/auth/oauth/components/KakaoSignUpForm.tsx
+++ b/src/features/auth/oauth/components/KakaoSignUpForm.tsx
@@ -1,0 +1,79 @@
+import { useRouter } from 'next/navigation';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { isAxiosError } from 'axios';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import Button from '@/shared/components/Button';
+import Input from '@/shared/components/Input';
+import { useUserStore } from '@/shared/stores/userStore';
+
+import { kakaoSignUpRequest } from '../../api/authApi';
+import { KakaoSignUpSchema, kakaoSignUpSchema } from '../../schemas/authSchema';
+import { setCookie } from '../../utils/cookie';
+
+interface Props {
+  kakaoCode: string;
+}
+
+const KakaoSignUpForm = ({ kakaoCode }: Props) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    mode: 'onChange',
+    resolver: zodResolver(kakaoSignUpSchema),
+    defaultValues: {
+      nickname: '',
+    },
+  });
+  const setUser = useUserStore((state) => state.setUser);
+  const router = useRouter();
+
+  const onSubmit: SubmitHandler<KakaoSignUpSchema> = async (data) => {
+    try {
+      const res = await kakaoSignUpRequest({
+        redirectUri: `${window.location.origin}/oauth/kakao`,
+        token: kakaoCode,
+        ...data,
+      });
+      const { accessToken } = res;
+
+      if (accessToken) {
+        setCookie('accessToken', accessToken);
+      }
+
+      setUser();
+      console.log(res.user?.nickname, '님 환영합니다'); //토스트 로그인 처리
+      router.replace('/');
+    } catch (e) {
+      if (isAxiosError(e)) {
+        const message = e.response?.data.message;
+        console.log(message); //추후에 토스트 메시지로 활용, 이메일 중복/닉네임 중복
+      }
+    }
+  };
+
+  return (
+    <form
+      className='mx-auto flex flex-col gap-15 px-5 pt-57 md:w-110 md:gap-10 md:pt-94 xl:w-160 xl:pt-79'
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Input
+        label='닉네임'
+        id='nickname'
+        type='text'
+        placeholder='닉네임을 입력해 주세요'
+        helperText='최대 20자 가능'
+        error={errors.nickname}
+        {...register('nickname')}
+      />
+      <Button className='max-w-none' type='submit' variant='primary' disabled={isSubmitting}>
+        {isSubmitting ? '요청 대기중...' : '가입하기'}
+      </Button>
+    </form>
+  );
+};
+
+export default KakaoSignUpForm;

--- a/src/features/auth/oauth/components/KakaoSignUpForm.tsx
+++ b/src/features/auth/oauth/components/KakaoSignUpForm.tsx
@@ -34,7 +34,7 @@ const KakaoSignUpForm = ({ kakaoCode }: Props) => {
   const onSubmit: SubmitHandler<KakaoSignUpSchema> = async (data) => {
     try {
       const res = await kakaoSignUpRequest({
-        redirectUri: `${window.location.origin}/oauth/kakao`,
+        redirectUri: `${window.location.origin}/oauth/signup/kakao`,
         token: kakaoCode,
         ...data,
       });
@@ -50,7 +50,7 @@ const KakaoSignUpForm = ({ kakaoCode }: Props) => {
     } catch (e) {
       if (isAxiosError(e)) {
         const message = e.response?.data.message;
-        console.log(message); //추후에 토스트 메시지로 활용, 이메일 중복/닉네임 중복
+        console.log(message); //추후에 토스트 메시지로 활용, 닉네임 중복
       }
     }
   };

--- a/src/features/auth/schemas/authSchema.ts
+++ b/src/features/auth/schemas/authSchema.ts
@@ -32,3 +32,10 @@ export const signInSchema = z.object({
 });
 
 export type SignInSchema = z.infer<typeof signInSchema>;
+
+//간편 회원가입
+export const kakaoSignUpSchema = z.object({
+  nickname: requiredString.max(20, { message: '닉네임은 최대 20자까지 가능합니다.' }),
+});
+
+export type KakaoSignUpSchema = z.infer<typeof kakaoSignUpSchema>;

--- a/src/features/auth/signIn/components/SocialLogin.tsx
+++ b/src/features/auth/signIn/components/SocialLogin.tsx
@@ -1,12 +1,42 @@
+'use client';
+
+// import { usePathname } from 'next/navigation';
+
 import KakaoIcon from '../../../../../public/icons/KakaoIcon.svg';
 
+const KAKAO_AUTH_URL = 'https://kauth.kakao.com/oauth/authorize';
+
 const SocialLogin = () => {
+  // const pathname = usePathname();
+  const currentOrigin = window.location.origin;
+
+  const handleClickKakaoLogin = () => {
+    if (!process.env.NEXT_PUBLIC_KAKAO_APP_KEY) {
+      return;
+    }
+
+    const params = {
+      client_id: process.env.NEXT_PUBLIC_KAKAO_APP_KEY,
+      redirect_uri: `${currentOrigin}/oauth/kakao`,
+      response_type: 'code',
+      // redirect 로직을 처리할 때 사용 예정
+      // state: pathname,
+    };
+    const queryString = new URLSearchParams(params).toString();
+    window.location.href = `${KAKAO_AUTH_URL}?${queryString}`;
+  };
+
   return (
     <div className='mt-15 flex items-center justify-center gap-4'>
       <span className='text-md-regular xl:text-base-regular text-gray-600'>
         SNS로 바로 시작하기
       </span>
-      <button className='cursor-pointer' type='button' aria-label='카카오톡 소셜 로그인 버튼'>
+      <button
+        className='cursor-pointer'
+        type='button'
+        aria-label='카카오톡 소셜 로그인 버튼'
+        onClick={handleClickKakaoLogin}
+      >
         <KakaoIcon />
       </button>
     </div>

--- a/src/features/auth/signIn/components/SocialLogin.tsx
+++ b/src/features/auth/signIn/components/SocialLogin.tsx
@@ -1,29 +1,11 @@
 'use client';
 
-// import { usePathname } from 'next/navigation';
-
 import KakaoIcon from '../../../../../public/icons/KakaoIcon.svg';
-
-const KAKAO_AUTH_URL = 'https://kauth.kakao.com/oauth/authorize';
+import moveToKakao from '../../utils/moveToKakao';
 
 const SocialLogin = () => {
-  // const pathname = usePathname();
-  const currentOrigin = window.location.origin;
-
   const handleClickKakaoLogin = () => {
-    if (!process.env.NEXT_PUBLIC_KAKAO_APP_KEY) {
-      return;
-    }
-
-    const params = {
-      client_id: process.env.NEXT_PUBLIC_KAKAO_APP_KEY,
-      redirect_uri: `${currentOrigin}/oauth/kakao`,
-      response_type: 'code',
-      // redirect 로직을 처리할 때 사용 예정
-      // state: pathname,
-    };
-    const queryString = new URLSearchParams(params).toString();
-    window.location.href = `${KAKAO_AUTH_URL}?${queryString}`;
+    moveToKakao('/oauth/kakao');
   };
 
   return (

--- a/src/features/auth/types/authTypes.ts
+++ b/src/features/auth/types/authTypes.ts
@@ -4,3 +4,12 @@ export interface AuthResponse {
   accessToken: string;
   user: BaseUser & { email: string };
 }
+
+export interface KakaoLoginData {
+  redirectUri: string;
+  token: string;
+}
+
+export interface KakaoSignUpData extends KakaoLoginData {
+  nickname: string;
+}

--- a/src/features/auth/utils/moveToKakao.ts
+++ b/src/features/auth/utils/moveToKakao.ts
@@ -1,0 +1,22 @@
+import { KAKAO_AUTH_URL } from '@/shared/constants/constants';
+
+//카카오 로그인 화면으로 이동해 인가 코드를 받아옴
+const moveToKakao = (redirectUri: string, pathname = '') => {
+  const currentOrigin = window.location.origin;
+
+  if (!process.env.NEXT_PUBLIC_KAKAO_APP_KEY) {
+    return;
+  }
+
+  const params = {
+    client_id: process.env.NEXT_PUBLIC_KAKAO_APP_KEY,
+    redirect_uri: `${currentOrigin}${redirectUri}`,
+    response_type: 'code',
+    // redirect 로직을 처리할 때 사용 예정
+    state: pathname,
+  };
+  const queryString = new URLSearchParams(params).toString();
+  window.location.href = `${KAKAO_AUTH_URL}?${queryString}`;
+};
+
+export default moveToKakao;

--- a/src/features/auth/utils/moveToKakao.ts
+++ b/src/features/auth/utils/moveToKakao.ts
@@ -5,6 +5,7 @@ const moveToKakao = (redirectUri: string, pathname = '') => {
   const currentOrigin = window.location.origin;
 
   if (!process.env.NEXT_PUBLIC_KAKAO_APP_KEY) {
+    console.log('App Key missing');
     return;
   }
 

--- a/src/shared/components/LoadingImage.tsx
+++ b/src/shared/components/LoadingImage.tsx
@@ -1,13 +1,15 @@
 import LoadingIcon from '../../../public/icons/LoadingIcon.svg';
 
-const LOADING_TEXT = 'Loading...';
+interface Props {
+  loadingText: string;
+}
 
-const LoadingImage = () => {
+const LoadingImage = ({ loadingText }: Props) => {
   return (
     <div className='text-xl-regular flex h-21 flex-col items-center justify-between text-gray-600'>
       <LoadingIcon />
       <div>
-        {LOADING_TEXT.split('').map((letter, i) => (
+        {loadingText.split('').map((letter, i) => (
           <span
             className='bounce-delay inline-block'
             key={i}

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -17,3 +17,4 @@ export const CATEGORIES: Category[] = [
 
 // api url/key
 export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+export const KAKAO_AUTH_URL = 'https://kauth.kakao.com/oauth/authorize';


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->
카카오 소셜 로그인 구현했습니다.

![녹음 2025-08-31 150211](https://github.com/user-attachments/assets/58b58e8f-bbad-4ae9-99a3-921831c4428e)

카카오 로그인을 시도해서, 회원가입이 되어있지 않다면 간편 회원가입 페이지로 이동합니다.
<img width="807" height="801" alt="스크린샷 2025-08-31 152510" src="https://github.com/user-attachments/assets/cdfda53c-2180-44a0-aa02-19165811e191" />


과정중에 생기는 에러는 에러처리 ui로 넘어갑니다. (요청 에러, 인가 코드 없이 페이지 직접 접근 시도 등)
<img width="827" height="930" alt="image" src="https://github.com/user-attachments/assets/a0ca768b-b52a-4684-900e-b2a33c46eac8" />


## 📌 변경 범위

로그인, 회원가입

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
개발환경에서 카카오 로그인 시 콘솔에 에러가 출력되는데, strictMode로 인한 useEffect 2번 실행으로 api 요청을 2번 전송하는 것을 원인으로 생각하고 있습니다. 영상 중간에 잠깐 에러 화면이 나오는 것도 순간 에러 처리를 하기 때문입니다. 배포 환경에서는 아마 에러가 없을 것으로 생각하고 있습니다.
(strict모드를 끄고 실행 시 에러가 나오지 않는 것을 확인했습니다.)

그리고 중간중간 state자체에 주석이 되어있지 않고, 이후 사용한다는 설명만 주석 처리된 곳이 있는데 일단 그 부분은 넘어가시면 될 것 같습니다.