### PR TITLE
[Hoy 23] fix: 홈, 프로필 아이템 카드 이미지 테두리에 rounded-lg적용(김인)

### DIFF
--- a/src/shared/components/HomeItemCard.tsx
+++ b/src/shared/components/HomeItemCard.tsx
@@ -49,8 +49,8 @@ const HomeItemCard = ({
     <Link href={`/product/${contentId}`} className={clsx(CARD_BASE_STYLE, className)}>
       {/* 아이템 요소 컨테이너 */}
       <div className='flex w-full flex-col gap-[10px]'>
-        {/* 이미지 컨테이너 - api 이미지 비율이 다를 경우 깨질 수 있어 고정 값 대신 해당 사항 적용 + 최소 너비 min-w 추가 */}
-        <div className='relative aspect-[14/9] w-full min-w-[140px]'>
+        {/* 이미지 컨테이너 - api 이미지 비율이 다를 경우 깨질 수 있어 고정 값 대신 해당 사항 적용 + 최소 너비 min-w 추가 이미지에 rounded-lg 적용 */}
+        <div className='relative aspect-[14/9] w-full min-w-[140px] overflow-hidden rounded-lg'>
           <SafeImage src={contentImage} alt={title} fill className='object-cover' />
         </div>
         {/* 제목 및 값 섹션 */}


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)
<img width="1437" height="1368" alt="스크린샷 2025-09-03 222212" src="https://github.com/user-attachments/assets/983881c3-b7fe-4a19-b29e-3b81aec56940" />

- 아이템 카드 이미지 부분에 카드 모서리 둥글기와 같은 rounded-lg (4px)을 적용했습니다.

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위
src/shared/components/HomeItemCard.tsx: 이미지 모서리 적용
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항
해당 부분을 자주 쓰실 혜민님과 유진님에게 확인을 부탁드리도록 하겠습니다.
<!-- 리뷰어와 논의하고 싶은 부분 -->
