### PR TITLE
[HOY-34] 콘텐츠 상세 정보 수정 모달 & 삭제 확인 모달 UI 구현 (이관현)

### DIFF
--- a/src/features/product/components/productCard/productButtons.tsx
+++ b/src/features/product/components/productCard/productButtons.tsx
@@ -6,11 +6,17 @@ interface ProductButtonsProps {
   isEditable: boolean;
   className?: string;
   onReviewButtonClick: () => void;
+  onEditButtonClick?: () => void;
 }
 
 const BUTTON_STYLES = 'w-full max-w-none rounded-[8px] md:flex-1';
 
-const ProductButtons = ({ isEditable, className, onReviewButtonClick }: ProductButtonsProps) => {
+const ProductButtons = ({
+  isEditable,
+  className,
+  onReviewButtonClick,
+  onEditButtonClick,
+}: ProductButtonsProps) => {
   return (
     <div className={`flex flex-col gap-[15px] md:flex-row ${className}`}>
       <Button variant='primary' className={BUTTON_STYLES} onClick={onReviewButtonClick}>
@@ -20,8 +26,8 @@ const ProductButtons = ({ isEditable, className, onReviewButtonClick }: ProductB
         비교하기
       </Button>
       {isEditable && (
-        <Button variant='tertiary' className={BUTTON_STYLES}>
-          편집하기
+        <Button variant='tertiary' className={BUTTON_STYLES} onClick={onEditButtonClick}>
+          편집/삭제
         </Button>
       )}
     </div>

--- a/src/features/product/components/productCard/productButtons.tsx
+++ b/src/features/product/components/productCard/productButtons.tsx
@@ -27,7 +27,7 @@ const ProductButtons = ({
       </Button>
       {isEditable && (
         <Button variant='tertiary' className={BUTTON_STYLES} onClick={onEditButtonClick}>
-          편집/삭제
+          편집하기
         </Button>
       )}
     </div>

--- a/src/features/product/components/productCard/productCard.tsx
+++ b/src/features/product/components/productCard/productCard.tsx
@@ -10,6 +10,7 @@ import { formatNumber } from '@/shared/utils/formatters';
 import ProductButtons from './productButtons';
 import ProductDescription from './productDescription';
 import ProductHeader from './productHeader';
+import EditDeleteModal from '../productModal/editDeleteModal';
 import ReviewAddModal from '../productModal/reviewAddModal';
 
 interface ProductCardProps {
@@ -36,6 +37,8 @@ const ProductCard = ({
 
   const [isReviewAddModalOpen, setIsReviewAddModalOpen] = useState(false);
   const [isRedirectModalOpen, setIsRedirectModalOpen] = useState(false);
+  const [isEditDeleteModalOpen, setIsEditDeleteModalOpen] = useState(false);
+
   // 임시로 rating 상태를 추가/ TODO: API 연결
   const [userRating, setUserRating] = useState<number>(4);
 
@@ -67,6 +70,7 @@ const ProductCard = ({
             isEditable={isEditable}
             className='mt-[40px] md:mt-[60px]'
             onReviewButtonClick={handleReviewButtonClick}
+            onEditButtonClick={() => setIsEditDeleteModalOpen(true)}
           />
         </div>
       </div>
@@ -80,6 +84,12 @@ const ProductCard = ({
 
       {/* 로그인 화면 이동 모달 */}
       <RedirectModal isOpen={isRedirectModalOpen} onClose={() => setIsRedirectModalOpen(false)} />
+
+      {/* 편집/삭제 모달 */}
+      <EditDeleteModal
+        isOpen={isEditDeleteModalOpen}
+        onClose={() => setIsEditDeleteModalOpen(false)}
+      />
     </>
   );
 };

--- a/src/features/product/components/productModal/editDeleteModal.tsx
+++ b/src/features/product/components/productModal/editDeleteModal.tsx
@@ -1,11 +1,11 @@
-// EditDeleteModal.tsx
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 
 import BaseModal from '@/shared/components/BaseModal';
 import Button from '@/shared/components/Button';
 import { Chip } from '@/shared/components/chip';
+import DeleteConfirmModal from '@/shared/components/deleteConfirmModal';
 import ImageUploader from '@/shared/components/imageUploader';
 import TextAreaWithCounter from '@/shared/components/textAreaWithCounter';
 import { toCategoryChip } from '@/shared/utils/categoryUtil';
@@ -24,52 +24,77 @@ export default function EditDeleteModal({
   category = { id: 1, name: '영화' },
 }: EditDeleteModalProps) {
   const [images, setImages] = useState<File[]>([]);
-  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
   const [text, setText] = useState('');
 
+  /* 삭제 확인 모달 상태 */
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  /* 미리보기 URL */
+  const previewUrls = useMemo(() => {
+    return images.map((file) => URL.createObjectURL(file));
+  }, [images]);
+
+  /* cleanup: URL 해제 */
+  useEffect(() => {
+    return () => {
+      previewUrls.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [previewUrls]);
+
   return (
-    <BaseModal title='수정/삭제 모달' isOpen={isOpen} onClose={onClose} size='L'>
-      <div className='flex flex-col px-5 pb-5'>
-        <h2 className='text-xl-semibold xl:text-2xl-semibold'>콘텐츠 수정/삭제</h2>
-        {/* 카테고리 칩 */}
-        <div className='mt-5 flex justify-start'>
-          <Chip {...toCategoryChip(category)} />
+    <div>
+      <BaseModal title='수정/삭제 모달' isOpen={isOpen} onClose={onClose} size='L'>
+        <div className='flex flex-col px-5 pb-5 md:px-10 md:pb-10'>
+          {/* 카테고리 칩 */}
+          <div className='flex justify-start'>
+            <Chip {...toCategoryChip(category)} />
+          </div>
+
+          {/* 콘텐츠명 */}
+          <h2 className='text-xl-semibold xl:text-2xl-semibold mt-2.5'>{name}</h2>
+
+          {/* 이미지 업로더 */}
+          <ImageUploader
+            value={images}
+            onChange={setImages}
+            onRemove={(index) => {
+              setImages((prev) => prev.filter((_, i) => i !== index));
+            }}
+            previewUrls={previewUrls}
+            maxImages={1}
+            className='mt-10'
+          />
+
+          {/* 설명 입력 */}
+          <TextAreaWithCounter
+            value={text}
+            onChange={setText}
+            placeholder='감독, 출연진, 줄거리 등을 입력해 주세요.'
+            className='mt-2.5 md:mt-3.5'
+          />
+
+          {/* 버튼 영역 */}
+          <div className='mt-5 flex flex-row gap-4 md:mt-10'>
+            <Button variant='secondary' onClick={() => setIsDeleteModalOpen(true)}>
+              삭제하기
+            </Button>
+            <Button variant='primary' disabled={images.length === 0 || text.trim() === ''}>
+              수정하기
+            </Button>
+          </div>
         </div>
+      </BaseModal>
 
-        {/* 콘텐츠명 */}
-        <h2 className='text-xl-semibold xl:text-2xl-semibold mt-2.5'>{name}</h2>
-
-        {/* 이미지 업로더 */}
-        <ImageUploader
-          value={images}
-          onChange={(files) => {
-            setImages(files);
-            setPreviewUrls(files.map((f) => URL.createObjectURL(f)));
-          }}
-          onRemove={(index) => {
-            const newFiles = images.filter((_, i) => i !== index);
-            setImages(newFiles);
-            setPreviewUrls(newFiles.map((f) => URL.createObjectURL(f)));
-          }}
-          previewUrls={previewUrls}
-          maxImages={1}
-          className='mt-5'
-        />
-
-        {/* 설명 입력 */}
-        <TextAreaWithCounter
-          value={text}
-          onChange={setText}
-          placeholder='감독, 출연진, 줄거리 등을 입력해 주세요.'
-          className='mt-2.5'
-        />
-
-        {/* 버튼 영역 */}
-        <div className='mt-5 flex flex-row gap-4'>
-          <Button variant='secondary'>삭제하기</Button>
-          <Button variant='primary'>수정하기</Button>
-        </div>
-      </div>
-    </BaseModal>
+      {/* 삭제 확인 모달 */}
+      <DeleteConfirmModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={() => {
+          console.log('삭제 confirmed');
+          setIsDeleteModalOpen(false);
+          onClose();
+        }}
+      />
+    </div>
   );
 }

--- a/src/features/product/components/productModal/editDeleteModal.tsx
+++ b/src/features/product/components/productModal/editDeleteModal.tsx
@@ -1,0 +1,65 @@
+// EditDeleteModal.tsx
+'use client';
+
+import { useState } from 'react';
+
+import BaseModal from '@/shared/components/BaseModal';
+import Button from '@/shared/components/Button';
+import Dropdown from '@/shared/components/Dropdown';
+import ImageUploader from '@/shared/components/imageUploader';
+import TextAreaWithCounter from '@/shared/components/textAreaWithCounter';
+
+interface EditDeleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const dummyOptions = [
+  { name: '옵션 1', value: '1' },
+  { name: '옵션 2', value: '2' },
+];
+
+export default function EditDeleteModal({ isOpen, onClose }: EditDeleteModalProps) {
+  const [images, setImages] = useState<File[]>([]);
+  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
+  const [text, setText] = useState('');
+
+  return (
+    <BaseModal title='편집/삭제 모달' isOpen={isOpen} onClose={onClose} size='L'>
+      <div className='flex flex-col gap-4'>
+        <div className='flex flex-col gap-4 md:flex-row'>
+          <div className='order-1 md:order-2 md:w-1/2'>
+            <ImageUploader
+              value={images}
+              onChange={(files) => {
+                setImages(files);
+                setPreviewUrls(files.map((f) => URL.createObjectURL(f)));
+              }}
+              onRemove={(index) => {
+                const newFiles = images.filter((_, i) => i !== index);
+                setImages(newFiles);
+                setPreviewUrls(newFiles.map((f) => URL.createObjectURL(f)));
+              }}
+              previewUrls={previewUrls}
+            />
+          </div>
+
+          {/* 드롭다운 */}
+          <div className='order-2 flex flex-col gap-4 md:order-1 md:w-1/2'>
+            <Dropdown options={dummyOptions} onChange={() => {}} placeholder='드롭다운 1' />
+            <Dropdown options={dummyOptions} onChange={() => {}} placeholder='드롭다운 2' />
+          </div>
+        </div>
+
+        {/* 텍스트 인풋 */}
+        <TextAreaWithCounter value={text} onChange={setText} placeholder='텍스트 입력' />
+
+        {/* 버튼 영역 */}
+        <div className='flex flex-row gap-4'>
+          <Button variant='primary'>삭제하기</Button>
+          <Button variant='primary'>저장하기</Button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/features/product/components/productModal/editDeleteModal.tsx
+++ b/src/features/product/components/productModal/editDeleteModal.tsx
@@ -5,59 +5,69 @@ import { useState } from 'react';
 
 import BaseModal from '@/shared/components/BaseModal';
 import Button from '@/shared/components/Button';
-import Dropdown from '@/shared/components/Dropdown';
+import { Chip } from '@/shared/components/chip';
 import ImageUploader from '@/shared/components/imageUploader';
 import TextAreaWithCounter from '@/shared/components/textAreaWithCounter';
+import { toCategoryChip } from '@/shared/utils/categoryUtil';
 
 interface EditDeleteModalProps {
   isOpen: boolean;
   onClose: () => void;
+  name?: string;
+  category?: { id: number; name: string };
 }
 
-const dummyOptions = [
-  { name: '옵션 1', value: '1' },
-  { name: '옵션 2', value: '2' },
-];
-
-export default function EditDeleteModal({ isOpen, onClose }: EditDeleteModalProps) {
+export default function EditDeleteModal({
+  isOpen,
+  onClose,
+  name = '뷰티 인사이드',
+  category = { id: 1, name: '영화' },
+}: EditDeleteModalProps) {
   const [images, setImages] = useState<File[]>([]);
   const [previewUrls, setPreviewUrls] = useState<string[]>([]);
   const [text, setText] = useState('');
 
   return (
-    <BaseModal title='편집/삭제 모달' isOpen={isOpen} onClose={onClose} size='L'>
-      <div className='flex flex-col gap-4'>
-        <div className='flex flex-col gap-4 md:flex-row'>
-          <div className='order-1 md:order-2 md:w-1/2'>
-            <ImageUploader
-              value={images}
-              onChange={(files) => {
-                setImages(files);
-                setPreviewUrls(files.map((f) => URL.createObjectURL(f)));
-              }}
-              onRemove={(index) => {
-                const newFiles = images.filter((_, i) => i !== index);
-                setImages(newFiles);
-                setPreviewUrls(newFiles.map((f) => URL.createObjectURL(f)));
-              }}
-              previewUrls={previewUrls}
-            />
-          </div>
-
-          {/* 드롭다운 */}
-          <div className='order-2 flex flex-col gap-4 md:order-1 md:w-1/2'>
-            <Dropdown options={dummyOptions} onChange={() => {}} placeholder='드롭다운 1' />
-            <Dropdown options={dummyOptions} onChange={() => {}} placeholder='드롭다운 2' />
-          </div>
+    <BaseModal title='수정/삭제 모달' isOpen={isOpen} onClose={onClose} size='L'>
+      <div className='flex flex-col px-5 pb-5'>
+        <h2 className='text-xl-semibold xl:text-2xl-semibold'>콘텐츠 수정/삭제</h2>
+        {/* 카테고리 칩 */}
+        <div className='mt-5 flex justify-start'>
+          <Chip {...toCategoryChip(category)} />
         </div>
 
-        {/* 텍스트 인풋 */}
-        <TextAreaWithCounter value={text} onChange={setText} placeholder='텍스트 입력' />
+        {/* 콘텐츠명 */}
+        <h2 className='text-xl-semibold xl:text-2xl-semibold mt-2.5'>{name}</h2>
+
+        {/* 이미지 업로더 */}
+        <ImageUploader
+          value={images}
+          onChange={(files) => {
+            setImages(files);
+            setPreviewUrls(files.map((f) => URL.createObjectURL(f)));
+          }}
+          onRemove={(index) => {
+            const newFiles = images.filter((_, i) => i !== index);
+            setImages(newFiles);
+            setPreviewUrls(newFiles.map((f) => URL.createObjectURL(f)));
+          }}
+          previewUrls={previewUrls}
+          maxImages={1}
+          className='mt-5'
+        />
+
+        {/* 설명 입력 */}
+        <TextAreaWithCounter
+          value={text}
+          onChange={setText}
+          placeholder='감독, 출연진, 줄거리 등을 입력해 주세요.'
+          className='mt-2.5'
+        />
 
         {/* 버튼 영역 */}
-        <div className='flex flex-row gap-4'>
-          <Button variant='primary'>삭제하기</Button>
-          <Button variant='primary'>저장하기</Button>
+        <div className='mt-5 flex flex-row gap-4'>
+          <Button variant='secondary'>삭제하기</Button>
+          <Button variant='primary'>수정하기</Button>
         </div>
       </div>
     </BaseModal>

--- a/src/features/product/components/productModal/reviewAddModal.tsx
+++ b/src/features/product/components/productModal/reviewAddModal.tsx
@@ -75,10 +75,18 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
     onClose();
   };
 
+  const handleReviewBlur = () => {
+    if (reviewText.trim().length === 0) {
+      toast.error('리뷰 내용을 입력해주세요.');
+    } else if (reviewText.trim().length < 10) {
+      toast.error('최소 10자 이상 적어주세요.');
+    }
+  };
+
   const productCategory = { id: 1, name: '' };
   const categoryChipProps = toCategoryChip(productCategory);
 
-  const isReviewValid = reviewText.trim().length > 0;
+  const isReviewValid = reviewText.trim().length > 10;
 
   return (
     <BaseModal title='리뷰 작성 모달' isOpen={isOpen} onClose={handleModalClose} size='L'>
@@ -108,6 +116,7 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
         <TextAreaWithCounter
           value={reviewText}
           onChange={setReviewText}
+          onBlur={handleReviewBlur}
           maxLength={500}
           placeholder='리뷰를 작성해 주세요'
           className='mt-3 md:mt-4'

--- a/src/features/product/components/productModal/reviewAddModal.tsx
+++ b/src/features/product/components/productModal/reviewAddModal.tsx
@@ -24,6 +24,8 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
   const [reviewText, setReviewText] = useState('');
   const [imageFiles, setImageFiles] = useState<File[]>([]);
 
+  const maxImages = 3;
+
   const previews = useMemo<ImageEntry[]>(() => {
     return imageFiles.map((file) => ({
       file,
@@ -56,7 +58,7 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
 
     if (uniqueNewFiles.length === 0) return;
 
-    const remain = 3 - imageFiles.length;
+    const remain = maxImages - imageFiles.length;
     if (remain <= 0) return;
 
     const filesToAdd = uniqueNewFiles.slice(0, remain);
@@ -115,11 +117,11 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
           onChange={handleImageChange}
           onRemove={handleImageRemove}
           previewUrls={previews.map((p) => p.url)}
-          maxImages={3}
+          maxImages={maxImages}
           className='mt-2.5'
         />
         <p className='text-xs-medium mt-1.5 text-gray-400'>
-          이미지는 최대 3개까지 첨부할 수 있습니다.
+          이미지는 최대 {maxImages}개까지 첨부할 수 있습니다.
         </p>
         <Button
           variant='primary'

--- a/src/features/product/components/productModal/reviewAddModal.tsx
+++ b/src/features/product/components/productModal/reviewAddModal.tsx
@@ -51,13 +51,7 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
     });
 
     if (duplicatesFound) {
-      toast.error(
-        <div>
-          이미 존재하는 파일은
-          <br />
-          추가할 수 없습니다.
-        </div>,
-      );
+      toast.error('이미 존재하는 파일은\n추가할 수 없습니다.');
     }
 
     if (uniqueNewFiles.length === 0) return;

--- a/src/features/product/components/productModal/reviewAddModal.tsx
+++ b/src/features/product/components/productModal/reviewAddModal.tsx
@@ -20,8 +20,6 @@ interface Props {
 
 type ImageEntry = { file: File; url: string };
 
-const MAX_IMAGES = 3;
-
 export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
   const [reviewText, setReviewText] = useState('');
   const [imageFiles, setImageFiles] = useState<File[]>([]);
@@ -64,7 +62,7 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
 
     if (uniqueNewFiles.length === 0) return;
 
-    const remain = MAX_IMAGES - imageFiles.length;
+    const remain = 3 - imageFiles.length;
     if (remain <= 0) return;
 
     const filesToAdd = uniqueNewFiles.slice(0, remain);
@@ -123,7 +121,7 @@ export default function ReviewAddModal({ isOpen, onClose, rating }: Props) {
           onChange={handleImageChange}
           onRemove={handleImageRemove}
           previewUrls={previews.map((p) => p.url)}
-          showAddButton={imageFiles.length < MAX_IMAGES}
+          maxImages={3}
           className='mt-2.5'
         />
         <p className='text-xs-medium mt-1.5 text-gray-400'>

--- a/src/shared/components/deleteConfirmModal.tsx
+++ b/src/shared/components/deleteConfirmModal.tsx
@@ -23,7 +23,7 @@ export default function DeleteConfirmModal({
         <AlertTriangle className='size-14 text-red-500' aria-hidden='true' />
 
         {/* 안내 문구 */}
-        <p className='text-base-semibold md:text-mg-semibold xl:text-xl-semibold mt-4 text-center'>
+        <p className='text-base-semibold md:text-lg-semibold xl:text-xl-semibold mt-4 text-center'>
           정말 삭제하시겠습니까?
         </p>
 

--- a/src/shared/components/deleteConfirmModal.tsx
+++ b/src/shared/components/deleteConfirmModal.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { AlertTriangle } from 'lucide-react';
+
+import BaseModal from '@/shared/components/BaseModal';
+import Button from '@/shared/components/Button';
+
+interface DeleteConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function DeleteConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+}: DeleteConfirmModalProps) {
+  return (
+    <BaseModal title='삭제 확인 모달' isOpen={isOpen} onClose={onClose} size='M'>
+      <div className='flex flex-col items-center px-6 pb-6'>
+        {/* 아이콘 */}
+        <AlertTriangle className='size-14 text-red-500' aria-hidden='true' />
+
+        {/* 안내 문구 */}
+        <p className='text-base-semibold md:text-mg-semibold xl:text-xl-semibold mt-4 text-center'>
+          정말 삭제하시겠습니까?
+        </p>
+
+        {/* 버튼 영역 */}
+        <div className='mt-6 flex w-full justify-center gap-4 xl:mt-7'>
+          <Button variant='secondary' className='flex-1' onClick={onClose}>
+            취소
+          </Button>
+          <Button variant='primary' className='flex-1' onClick={onConfirm}>
+            확인
+          </Button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/shared/components/imageUploader.tsx
+++ b/src/shared/components/imageUploader.tsx
@@ -91,6 +91,14 @@ export default function ImageUploader({
             htmlFor='file-upload'
             aria-label='이미지 첨부'
             tabIndex={0}
+            role='button'
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+
+                fileInputRef.current?.click();
+              }
+            }}
             className={cn(
               IMAGE_ITEM_BASE_CLASSES,
               IMAGE_ITEM_SIZES,

--- a/src/shared/components/imageUploader.tsx
+++ b/src/shared/components/imageUploader.tsx
@@ -21,9 +21,10 @@ interface ImageUploaderProps {
   previewUrls: string[];
 }
 
-const IMAGE_ITEM_BASE_CLASSES = 'bg-black-800 group relative rounded-[8px] border border-gray-700';
+const IMAGE_ITEM_BASE_CLASSES = 'bg-black-800 group relative rounded-[8px] border border-gray-600';
 
 const IMAGE_ITEM_SIZES = 'w-full aspect-square md:h-[135px] md:w-[135px] xl:h-[160px] xl:w-[160px]';
+
 const IMAGE_REMOVE_BUTTON_CLASSES =
   'bg-black-900/60 absolute top-1 right-1 rounded-full p-1 opacity-0 transition-opacity group-hover:opacity-100';
 
@@ -56,7 +57,14 @@ export default function ImageUploader({
 
   return (
     <div className={cn('flex flex-col gap-3', className)}>
-      <div className='grid grid-cols-3 gap-2'>
+      {/* 이미지 개수 별 레이아웃 */}
+      <div
+        className={cn(
+          maxImages === 1
+            ? 'flex' // 1장일 때
+            : `grid grid-cols-${maxImages} gap-2`, // 여러 장일 때
+        )}
+      >
         {previewUrls.map((previewUrl, index) => (
           <div
             key={`${value[index]?.name ?? 'img'}-${index}`}
@@ -82,10 +90,12 @@ export default function ImageUploader({
           <label
             htmlFor='file-upload'
             aria-label='이미지 첨부'
+            tabIndex={0}
             className={cn(
               IMAGE_ITEM_BASE_CLASSES,
               IMAGE_ITEM_SIZES,
               'hover:bg-black-700 flex cursor-pointer items-center justify-center transition-colors',
+              'focus:ring-main focus:ring-1 focus:outline-none',
             )}
           >
             <ImagePlus className='size-8 text-gray-600' />
@@ -98,7 +108,7 @@ export default function ImageUploader({
         type='file'
         ref={fileInputRef}
         onChange={handleFileChange}
-        multiple
+        {...(maxImages > 1 ? { multiple: true } : {})}
         accept='image/*'
         className='hidden'
       />

--- a/src/shared/components/imageUploader.tsx
+++ b/src/shared/components/imageUploader.tsx
@@ -9,16 +9,16 @@ import { cn } from '@/shared/lib/cn';
  * value: 현재 선택된 이미지 배열
  * onChange: 새로운 파일이 선택 되었을 때 호출되는 함수
  * onRemove: 이미지가 삭제되었을 때 호출되는 함수
+ * maxImages: 이미지 최대 개수 (기본값 1)
  * previewUrls: 이미지 미리보기
- * showAddButton: 이미지 추가 버튼 여부
  */
 interface ImageUploaderProps {
   value: File[];
   onChange: (newFiles: File[]) => void;
   onRemove: (index: number) => void;
+  maxImages?: number;
   className?: string;
   previewUrls: string[];
-  showAddButton?: boolean;
 }
 
 const IMAGE_ITEM_BASE_CLASSES = 'bg-black-800 group relative rounded-[8px] border border-gray-700';
@@ -31,16 +31,14 @@ export default function ImageUploader({
   value,
   onChange,
   onRemove,
+  maxImages = 1, // 기본값 1
   className,
   previewUrls,
-  showAddButton = true,
 }: ImageUploaderProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
-
-    /* 파일이 없거나 빈 배열인 경우 */
     if (!files || files.length === 0) {
       if (e.target) e.target.value = '';
       return;
@@ -54,10 +52,11 @@ export default function ImageUploader({
     onRemove(index);
   };
 
+  const canAddMore = value.length < maxImages;
+
   return (
     <div className={cn('flex flex-col gap-3', className)}>
       <div className='grid grid-cols-3 gap-2'>
-        {/* URL은 부모로부터 받은 previewUrls를 직접 사용 */}
         {previewUrls.map((previewUrl, index) => (
           <div
             key={`${value[index]?.name ?? 'img'}-${index}`}
@@ -68,7 +67,6 @@ export default function ImageUploader({
               alt={`첨부 이미지 ${index + 1}`}
               className='h-full w-full rounded-[8px] object-cover'
             />
-
             <button
               type='button'
               onClick={() => handleImageRemove(index)}
@@ -80,7 +78,7 @@ export default function ImageUploader({
           </div>
         ))}
 
-        {showAddButton && (
+        {canAddMore && (
           <label
             htmlFor='file-upload'
             aria-label='이미지 첨부'

--- a/src/shared/components/textAreaWithCounter.tsx
+++ b/src/shared/components/textAreaWithCounter.tsx
@@ -16,7 +16,7 @@ interface TextAreaWithCounterProps {
 }
 
 const TEXTAREA_CLASSES =
-  'bg-black-800 w-full resize-none rounded-[8px] border border-gray-700 p-4 pr-12 text-white placeholder-gray-500 cursor-pointer';
+  'bg-black-800 w-full resize-none rounded-[8px] border border-gray-600 p-4 pr-12 text-white placeholder-gray-500 cursor-pointer focus:outline-none focus:ring-1 focus:ring-main';
 
 export default function TextAreaWithCounter({
   value,

--- a/src/shared/components/textAreaWithCounter.tsx
+++ b/src/shared/components/textAreaWithCounter.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/shared/lib/cn';
 interface TextAreaWithCounterProps {
   value: string;
   onChange: (value: string) => void;
+  onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
   maxLength?: number;
   placeholder?: string;
   className?: string;

--- a/src/shared/components/toastProvider.tsx
+++ b/src/shared/components/toastProvider.tsx
@@ -29,6 +29,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
         draggable
         pauseOnHover
         theme='dark'
+        toastClassName='whitespace-pre-line'
       />
     </>
   );


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

콘텐츠 상세 정보를 수정할 수 있는 모달에서 기존 시안에는 콘텐츠명과 카테고리를 드롭다운으로 선택할 수 있게 되어있습니다.
하지만 해당 이미 등록한 콘텐츠를 상세 페이지에서 수정하고 콘텐츠명과 카테고리를 수정해버리면 페이지 하단에 통계와 
리뷰 내용 불일치 이슈가 발생하기에 콘텐츠명과 카테고리는 수정 불가로 변경하였습니다.
변경할 수 있는 것은 이미지와 설명 뿐입니다.

- 이미지와 설명 입력 시에만 수정하기 버튼 활성화가 되도록 구현했습니다.
- 삭제 시 사용자에게 한번 더 확인 시키기 위해 삭제 모달을 추가 구현했습니다.
- 이번 PR에 `ImageUploader.tsx` 에서 이미지 최대 개수를 정할 수 있는 `maxImages` props를 추가하였습니다.
- 토스트 줄바꿈을 위해 `pre-line` 추가하였습니다. 

## Before
<img width="377" height="368" alt="image" src="https://github.com/user-attachments/assets/816a281c-869b-49ee-ad1d-63a6ce058684" />

## After
<img width="621" height="690" alt="image" src="https://github.com/user-attachments/assets/844fe56c-697d-43bf-ba1e-a508b609f242" />



<img width="503" height="300" alt="image" src="https://github.com/user-attachments/assets/4aba5b0d-faf4-43d4-b278-bf3282bbeaeb" />

- 경고 아이콘 색은 메인 컬러가 좀 밝은 느낌이라 빨간색보단 다홍색으로 지정했습니다.

## 📌 변경 범위
상세 페이지 내 편집하기 버튼을 누를 시 나오는 상세 정보 수정 모달
삭제 시 확인이 필요한 모든 페이지 
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->

수정 부분이 많아서 Files Changed가 많은데 모달 부분만 봐주시면 될 것 같습니다!
