### PR TITLE
[HOY-143] refactor: apiClient 인스턴스를 단일 인스턴스로 통일, userStore에서 클라이언트 상태와 api 호출 분리, 인증 시스템 에러 처리 세분화와 토스트 도입 (윤정환)

### DIFF
--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -6,7 +6,7 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 
-import { kakaoSignInRequest } from '@/features/auth/api/authApi';
+import { getMe, kakaoSignInRequest } from '@/features/auth/api/authApi';
 import KakaoError from '@/features/auth/components/KakaoError';
 import { setCookie } from '@/features/auth/utils/cookie';
 import moveToKakao from '@/features/auth/utils/moveToKakao';
@@ -37,13 +37,23 @@ const KakaoCallbackPage = () => {
           setCookie('accessToken', accessToken);
         }
 
-        setUser();
-        toast.success(`${res.user?.nickname}님 환영합니다!`);
+        //받은 토큰으로 유저 정보 불러오기
+        try {
+          const user = await getMe();
 
-        if (redirectUrl) {
-          router.replace(redirectUrl);
-        } else {
-          router.replace('/');
+          if (user) {
+            setUser(user);
+          }
+
+          toast.success(`${res.user?.nickname}님 환영합니다!`);
+
+          if (redirectUrl) {
+            router.replace(redirectUrl);
+          } else {
+            router.replace('/');
+          }
+        } catch (e) {
+          throw e;
         }
       } catch (e) {
         if (axios.isAxiosError(e) && e.status === 403) {

--- a/src/app/oauth/signup/kakao/page.tsx
+++ b/src/app/oauth/signup/kakao/page.tsx
@@ -2,21 +2,30 @@
 
 import { useSearchParams } from 'next/navigation';
 
+import { useState } from 'react';
+
 import KakaoError from '@/features/auth/components/KakaoError';
 import KakaoSignUpForm from '@/features/auth/oauth/components/KakaoSignUpForm';
 
 const KakaoSignUpPage = () => {
+  const [hasError, setHasError] = useState(false);
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
   const redirectUrl = searchParams.get('state');
   const kakaoError = searchParams.get('error');
 
   //에러 발생 또는 로그인 플로우를 통해 접근하지 않고 직접 url입력 접근 등의 경우 차단
-  if (!code || kakaoError) return <KakaoError />;
+  if (!code || kakaoError || hasError) return <KakaoError />;
 
   return (
     <section>
-      <KakaoSignUpForm kakaoCode={code} redirectUrl={redirectUrl ? redirectUrl : ''} />
+      <KakaoSignUpForm
+        kakaoCode={code}
+        redirectUrl={redirectUrl ? redirectUrl : ''}
+        onError={() => {
+          setHasError(true);
+        }}
+      />
     </section>
   );
 };

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,4 +1,4 @@
-import { privateApiClient, publicApiClient } from '@/shared/api/apiClients';
+import { apiClient } from '@/shared/api/apiClients';
 import { DetailUser } from '@/shared/types/userTypes';
 
 import { SignInSchema, SignUpSchema } from '../schemas/authSchema';
@@ -6,7 +6,7 @@ import { AuthResponse, KakaoLoginData, KakaoSignUpData } from '../types/authType
 
 export const signUpRequest = async (data: SignUpSchema): Promise<AuthResponse> => {
   try {
-    const res = await publicApiClient.post('/auth/signUp', data);
+    const res = await apiClient.post('/auth/signUp', data);
     return res.data;
   } catch (e) {
     console.log('회원가입 요청 에러');
@@ -16,7 +16,7 @@ export const signUpRequest = async (data: SignUpSchema): Promise<AuthResponse> =
 
 export const signInRequest = async (data: SignInSchema): Promise<AuthResponse> => {
   try {
-    const res = await publicApiClient.post('/auth/signin', data);
+    const res = await apiClient.post('/auth/signin', data);
     return res.data;
   } catch (e) {
     console.log('로그인 요청 에러');
@@ -26,7 +26,7 @@ export const signInRequest = async (data: SignInSchema): Promise<AuthResponse> =
 
 export const getMe = async (): Promise<DetailUser> => {
   try {
-    const res = await privateApiClient.get('/users/me');
+    const res = await apiClient.get('/users/me');
     return res.data;
   } catch (e) {
     console.log('사용자 정보 요청 에러');
@@ -36,7 +36,7 @@ export const getMe = async (): Promise<DetailUser> => {
 
 export const kakaoSignInRequest = async (data: KakaoLoginData): Promise<AuthResponse> => {
   try {
-    const res = await publicApiClient.post('/auth/signIn/kakao', data);
+    const res = await apiClient.post('/auth/signIn/kakao', data);
     return res.data;
   } catch (e) {
     console.log('카카오 로그인 요청 에러');
@@ -46,7 +46,7 @@ export const kakaoSignInRequest = async (data: KakaoLoginData): Promise<AuthResp
 
 export const kakaoSignUpRequest = async (data: KakaoSignUpData): Promise<AuthResponse> => {
   try {
-    const res = await publicApiClient.post('/auth/signUp/kakao', data);
+    const res = await apiClient.post('/auth/signUp/kakao', data);
     return res.data;
   } catch (e) {
     console.log('카카오 간편 회원가입 요청 에러');

--- a/src/features/auth/components/RedirectModal.tsx
+++ b/src/features/auth/components/RedirectModal.tsx
@@ -20,12 +20,12 @@ const RedirectModal = ({ isOpen, onClose }: Props) => {
       <div className='p-5'>
         <p className='text-lg-medium md:text-xl-medium xl:text-2xl-medium text-center whitespace-pre-line'>{`로그인이 필요한 서비스입니다\n로그인 화면으로 이동하시겠습니까?`}</p>
         <div className='mt-5 flex gap-4 md:mt-10'>
-          <Link className='flex w-full' href={`/signin${query}`}>
-            <Button> 예</Button>
-          </Link>
           <Button variant='tertiary' onClick={onClose}>
             아니오
           </Button>
+          <Link className='flex w-full' href={`/signin${query}`}>
+            <Button> 예</Button>
+          </Link>
         </div>
       </div>
     </BaseModal>

--- a/src/features/auth/oauth/components/KakaoSignUpForm.tsx
+++ b/src/features/auth/oauth/components/KakaoSignUpForm.tsx
@@ -9,7 +9,7 @@ import Button from '@/shared/components/Button';
 import Input from '@/shared/components/Input';
 import { useUserStore } from '@/shared/stores/userStore';
 
-import { kakaoSignUpRequest } from '../../api/authApi';
+import { getMe, kakaoSignUpRequest } from '../../api/authApi';
 import { KakaoSignUpSchema, kakaoSignUpSchema } from '../../schemas/authSchema';
 import { setCookie } from '../../utils/cookie';
 
@@ -48,13 +48,23 @@ const KakaoSignUpForm = ({ kakaoCode, redirectUrl, onError }: Props) => {
         setCookie('accessToken', accessToken);
       }
 
-      setUser();
-      toast.success(`${res.user?.nickname}님 환영합니다!`);
+      //받은 토큰으로 유저 정보 불러오기
+      try {
+        const user = await getMe();
 
-      if (redirectUrl) {
-        router.replace(redirectUrl);
-      } else {
-        router.replace('/');
+        if (user) {
+          setUser(user);
+        }
+
+        toast.success(`${res.user?.nickname}님 환영합니다!`);
+
+        if (redirectUrl) {
+          router.replace(redirectUrl);
+        } else {
+          router.replace('/');
+        }
+      } catch (e) {
+        throw e;
       }
     } catch (e) {
       if (axios.isAxiosError(e)) {

--- a/src/features/auth/signIn/components/SignInForm.tsx
+++ b/src/features/auth/signIn/components/SignInForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import axios from 'axios';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'react-toastify';
 
 import Button from '@/shared/components/Button';
 import Input from '@/shared/components/Input';
@@ -46,7 +47,8 @@ const SignInForm = ({ redirectUrl }: Props) => {
       }
 
       setUser();
-      console.log(res.user?.nickname, '님 환영합니다'); //토스트 로그인 처리
+      toast.success(`${res.user?.nickname}님 환영합니다!`);
+
       if (redirectUrl) {
         router.replace(redirectUrl);
       } else {
@@ -58,20 +60,29 @@ const SignInForm = ({ redirectUrl }: Props) => {
         const status = e.status;
         //status 400에러 -> 유효성 검사 실패 -> 필드 에러 메시지 처리
         if (status === 400 && message.includes('이메일')) {
+          //존재하지 않는 이메일
           setError('email', { type: 'server', message: message });
+          return;
         } else if (status === 400 && message.includes('비밀번호')) {
+          //비밀번호 불일치
           setError('password', { type: 'server', message: message });
+          return;
         } else if (status === 400) {
+          //형식 불일치
           setError('email', { type: 'server', message: '이메일 또는 비밀번호를 다시 확인하세요.' });
           setError('password', {
             type: 'server',
             message: '이메일 또는 비밀번호를 다시 확인하세요.',
           });
-        } else {
-          // status 400 이외 에러 -> 네트워크 등 문제 -> 토스트로 처리
-          console.log(message, status); //추후에 토스트 출력 '알 수 없는 에러가 발생했습니다. 다시 시도하세요'
+          return;
         }
+        // status 400 이외 에러
+        toast.error(`문제가 발생했습니다.\n다시 시도해주세요.`);
+        throw e;
       }
+      // axios외 에러
+      toast.error(`문제가 발생했습니다.\n다시 시도해주세요.`);
+      throw e;
     }
   };
 

--- a/src/features/auth/signIn/components/SignInForm.tsx
+++ b/src/features/auth/signIn/components/SignInForm.tsx
@@ -12,7 +12,7 @@ import Input from '@/shared/components/Input';
 import PasswordInput from '@/shared/components/PasswordInput';
 import { useUserStore } from '@/shared/stores/userStore';
 
-import { signInRequest } from '../../api/authApi';
+import { getMe, signInRequest } from '../../api/authApi';
 import { SignInSchema, signInSchema } from '../../schemas/authSchema';
 import { setCookie } from '../../utils/cookie';
 
@@ -46,13 +46,23 @@ const SignInForm = ({ redirectUrl }: Props) => {
         setCookie('accessToken', accessToken);
       }
 
-      setUser();
-      toast.success(`${res.user?.nickname}님 환영합니다!`);
+      //받은 토큰으로 유저 정보 불러오기
+      try {
+        const user = await getMe();
 
-      if (redirectUrl) {
-        router.replace(redirectUrl);
-      } else {
-        router.replace('/');
+        if (user) {
+          setUser(user);
+        }
+
+        toast.success(`${res.user?.nickname}님 환영합니다!`);
+
+        if (redirectUrl) {
+          router.replace(redirectUrl);
+        } else {
+          router.replace('/');
+        }
+      } catch (e) {
+        throw e;
       }
     } catch (e) {
       if (axios.isAxiosError(e)) {

--- a/src/features/auth/signUp/components/SignUpForm.tsx
+++ b/src/features/auth/signUp/components/SignUpForm.tsx
@@ -12,7 +12,7 @@ import Input from '@/shared/components/Input';
 import PasswordInput from '@/shared/components/PasswordInput';
 import { useUserStore } from '@/shared/stores/userStore';
 
-import { signUpRequest } from '../../api/authApi';
+import { getMe, signUpRequest } from '../../api/authApi';
 import { signUpSchema, SignUpSchema } from '../../schemas/authSchema';
 import { setCookie } from '../../utils/cookie';
 
@@ -49,13 +49,23 @@ const SignUpForm = ({ redirectUrl }: Props) => {
         setCookie('accessToken', accessToken);
       }
 
-      setUser();
-      toast.success(`${res.user?.nickname}님 환영합니다!`);
+      //받은 토큰으로 유저 정보 불러오기
+      try {
+        const user = await getMe();
 
-      if (redirectUrl) {
-        router.replace(redirectUrl);
-      } else {
-        router.replace('/');
+        if (user) {
+          setUser(user);
+        }
+
+        toast.success(`${res.user?.nickname}님 환영합니다!`);
+
+        if (redirectUrl) {
+          router.replace(redirectUrl);
+        } else {
+          router.replace('/');
+        }
+      } catch (e) {
+        throw e;
       }
     } catch (e) {
       if (axios.isAxiosError(e)) {

--- a/src/shared/api/apiClients.ts
+++ b/src/shared/api/apiClients.ts
@@ -3,16 +3,7 @@ import Cookies from 'js-cookie';
 
 import { BASE_URL } from '../constants/constants';
 
-// 인증 토큰을 요구하지 않는 api 요청 instance
-export const publicApiClient: AxiosInstance = axios.create({
-  baseURL: BASE_URL,
-  timeout: 10000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-export const privateApiClient: AxiosInstance = axios.create({
+export const apiClient: AxiosInstance = axios.create({
   baseURL: BASE_URL,
   timeout: 10000,
   headers: {
@@ -21,7 +12,7 @@ export const privateApiClient: AxiosInstance = axios.create({
 });
 
 //토큰이 필요한 요청에 대한 인터셉터
-privateApiClient.interceptors.request.use(
+apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
     const accessToken = Cookies.get('accessToken');
 

--- a/src/shared/stores/userStore.ts
+++ b/src/shared/stores/userStore.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import { getMe } from '@/features/auth/api/authApi';
 import { getCookie, removeCookie } from '@/features/auth/utils/cookie';
 
 import { UserState } from '../types/userTypes';
@@ -11,25 +10,8 @@ export const useUserStore = create(
     (set, get) => ({
       user: null,
       isLoggedIn: false,
-      setUser: async () => {
-        try {
-          const user = await getMe();
-          if (user) {
-            set({ user, isLoggedIn: true });
-          }
-        } catch (e) {
-          console.log('유저 정보 불러오기 실패');
-          throw e;
-        }
-      },
-      //엑세스 토큰은 있는데 유저정보가 없는 경우 -> 로그인 상태 복구
-      restoreAuth: () => {
-        const accessToken = getCookie('accessToken');
-        const { isLoggedIn, setUser } = get();
-
-        if (accessToken && !isLoggedIn) {
-          setUser();
-        }
+      setUser: (user) => {
+        set({ user, isLoggedIn: true });
       },
       //사용자의 직접적인 로그아웃
       clearUser: () => {

--- a/src/shared/types/userTypes.ts
+++ b/src/shared/types/userTypes.ts
@@ -20,9 +20,8 @@ export interface DetailUser extends BaseUser {
 export interface UserState {
   user: DetailUser | null;
   isLoggedIn: boolean;
-  setUser: () => void;
+  setUser: (user: DetailUser) => void;
   updateUser: (updatedUser: DetailUser) => void;
-  restoreAuth: () => void;
   initializeAuth: () => void;
   clearUser: () => void;
 }


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->
## useUserStore 변경사항
- setUser 내에서 getMe() api 호출을 제거하고, 인증 과정에서 두 함수를 순차적으로 호출하도록 코드 분리
- useUserStore에서 restoreAuth 함수를 삭제하고, authGuard 컴포넌트로 이동

## apiClient 변경사항
기존: publicApiClient, privateApiClient 두 인스턴스로 분리
변경: **apiClient하나로 통일** -> 클라이언트 쪽에서 사용하는 api 호출은 apiClient만 쓰시면 됩니다.

## 토스트, 에러처리 세분화
- 로그인 성공
<img width="245" height="49" alt="스크린샷 2025-09-04 162427" src="https://github.com/user-attachments/assets/24c7fd7e-4655-496f-a46b-1d7ebe15f643" />

- 폼에서 처리하는 에러를 제외한 에러 발생시
<img width="251" height="65" alt="스크린샷 2025-09-04 152125" src="https://github.com/user-attachments/assets/1489c639-4aa5-40d1-b7f5-fb561c992f86" />

- 기존 console에 띄우던 에러를 폼에서 에러 메시지로 처리
<img width="355" height="102" alt="스크린샷 2025-09-04 162310" src="https://github.com/user-attachments/assets/65ed9e8d-0566-4bca-87dc-0037eddbac68" />
<img width="361" height="95" alt="스크린샷 2025-09-04 162333" src="https://github.com/user-attachments/assets/af64319c-cb65-4dbd-8d80-9cb9542b823c" />


## 📌 변경 범위

<!-- 영향 받는 서비스, 모듈, UI 등 -->
- 로그인, 회원가입, 소셜 로그인 등 전반적인 인증 시스템
- 모든 클라이언트 api 호출 함수

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
