### PR TITLE
[HOY-162] fix:비교 입력창 입력 오류 수정(김인)

### DIFF
--- a/src/features/compare/components/CompareSelect.tsx
+++ b/src/features/compare/components/CompareSelect.tsx
@@ -42,6 +42,29 @@ export type CompareSelectProps = {
 // 사용자가 입력한 값(query)을 DEBOUNCE_MS(ms기준) 기다린 후 debounced에 반영
 const DEBOUNCE_MS = 150;
 
+// 문자열 비교 유틸: 공백/대소문자/유니코드 정규화 등을 정리해서 완전 일치 판정 신뢰도 높임
+const normalizeForExactMatch = (input: string, locale: string = 'ko-KR'): string =>
+  input.normalize('NFKC').trim().toLocaleLowerCase(locale);
+
+// 완전 일치 항목의 인덱스를 찾아주는 헬퍼
+const findExactMatchIndex = (options: CompareCandidate[], query: string): number => {
+  const normalizedQuery = normalizeForExactMatch(query);
+  return options.findIndex((option) => normalizeForExactMatch(option.name) === normalizedQuery);
+};
+
+// IME(한글 등) 조합 중 여부를 추적하는 ref
+const isComposingRefGlobal = { current: false } as { current: boolean };
+
+// KeyboardEvent.isComposing 존재 여부 타입가드 (any 타입 사용 금지)
+const hasIsComposing = (evt: unknown): evt is { isComposing: boolean } => {
+  return (
+    typeof evt === 'object' &&
+    evt !== null &&
+    'isComposing' in evt &&
+    typeof (evt as { isComposing: unknown }).isComposing === 'boolean'
+  );
+};
+
 const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function CompareSelect(
   {
     label,
@@ -65,7 +88,7 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
 
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
 
   // 디바운스된 검색어
   const [debounced, setDebounced] = useState('');
@@ -127,22 +150,26 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
     },
   } as const;
 
-  // 드롭다운 열릴 때(또는 검색어가 안정화되면) 첫 항목 활성화
-  useEffect(() => {
-    if (open) setActiveIndex(0);
-  }, [open, debounced]);
-
-  // 필터 결과가 줄어드는 등 리스트 길이가 바뀌었을 때, activeIndex를 범위 안으로 보정
+  // 드롭다운이 열리거나(query가 안정화되거나) 목록이 바뀔 때 완전 일치가 있으면 그 항목을 하이라이트
   useEffect(() => {
     if (!open) return;
-
     if (filtered.length === 0) {
-      setActiveIndex(0);
+      setActiveIndex(-1);
       return;
     }
+    const exactIdx = findExactMatchIndex(filtered, query);
+    setActiveIndex(exactIdx !== -1 ? exactIdx : 0);
+  }, [open, debounced, filtered, query]);
 
+  // 리스트 길이가 바뀌었을 때 activeIndex 보정
+  useEffect(() => {
+    if (!open) return;
+    if (filtered.length === 0) {
+      setActiveIndex(-1);
+      return;
+    }
     if (activeIndex >= filtered.length) {
-      setActiveIndex(0);
+      setActiveIndex(filtered.length - 1);
     }
   }, [filtered.length, activeIndex, open]);
 
@@ -150,7 +177,7 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
   const handleSelect = (opt: CompareCandidate) => {
     if (opt.disabled) return;
 
-    // 1) onTryChange가 있으면 먼저 시도 → 실패(중복 등) 시 에러만 표시 후 종료
+    // onTryChange가 있으면 먼저 시도 → 실패(중복 등) 시 에러만 표시 후 종료
     if (onTryChange) {
       const res = onTryChange(opt);
       if (!res.ok) {
@@ -163,7 +190,7 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
       return; //  onChange는 호출하지 않음 (이중 업데이트 방지)
     }
 
-    // 2) fallback: 기존 onChange 사용(스토어 없이 로컬 사용 등)
+    // fallback: 기존 onChange 사용(스토어 없이 로컬 사용 등)
     onChange(opt);
     setOpen(false);
     setQuery('');
@@ -187,42 +214,78 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
     requestAnimationFrame(() => inputRef.current?.focus());
   };
 
+  // 타입가드 + composition 이벤트(ref)로 IME 조합 안전 처리
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // IME 조합 중이면 Enter는 조합 확정이므로 선택 로직을 실행시키지 않도록 수정
+    const composing =
+      isComposingRefGlobal.current || (hasIsComposing(e.nativeEvent) && e.nativeEvent.isComposing);
+
     if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
       setOpen(true);
       return;
     }
 
+    // 드롭다운이 닫혀 있는 상태에서 Enter:
+    // 1) 완전 일치가 있으면 그걸 선택, 2) 없으면 첫 항목(옵션)
     if (!open) {
-      if (e.key === 'Enter' && filtered[0] && !filtered[0].disabled) {
-        // 필터 결과가 있을 때 Enter로 첫 항목 선택(일반 검색처럼 보이도록 UX 보완)
-        handleSelect(filtered[0]);
+      if (e.key === 'Enter' && !composing) {
+        const exactIdx = findExactMatchIndex(filtered, query);
+        if (exactIdx !== -1 && !filtered[exactIdx]?.disabled) {
+          e.preventDefault();
+          handleSelect(filtered[exactIdx]);
+          return;
+        }
+        if (filtered[0] && !filtered[0].disabled) {
+          e.preventDefault();
+          handleSelect(filtered[0]);
+        }
       }
       return;
     }
 
+    // 드롭다운이 열려 있는 상태
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       if (!filtered.length) return;
-      let next = activeIndex;
+      let next = activeIndex < 0 ? 0 : activeIndex;
       do {
         next = (next + 1) % filtered.length;
       } while (filtered[next]?.disabled && next !== activeIndex);
       setActiveIndex(next);
-    } else if (e.key === 'ArrowUp') {
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
       e.preventDefault();
       if (!filtered.length) return;
-      let prev = activeIndex;
+      let prev = activeIndex < 0 ? 0 : activeIndex;
       do {
         prev = (prev - 1 + filtered.length) % filtered.length;
       } while (filtered[prev]?.disabled && prev !== activeIndex);
       setActiveIndex(prev);
-    } else if (e.key === 'Enter') {
+      return;
+    }
+
+    if (e.key === 'Enter' && !composing) {
       e.preventDefault();
-      const target = filtered[activeIndex];
-      if (target && !target.disabled) handleSelect(target);
-    } else if (e.key === 'Escape') {
+
+      // ★ 변경: 우선순위 — 1) 완전 일치 2) 활성 항목 3) 첫 항목(옵션)
+      const exactIdx = findExactMatchIndex(filtered, query);
+      if (exactIdx !== -1 && !filtered[exactIdx]?.disabled) {
+        handleSelect(filtered[exactIdx]);
+        return;
+      }
+      const target =
+        activeIndex !== -1 && filtered[activeIndex] ? filtered[activeIndex] : filtered[0];
+      if (target && !target.disabled) {
+        handleSelect(target);
+      }
+      return;
+    }
+
+    if (e.key === 'Escape') {
       setOpen(false);
+      setActiveIndex(-1);
     }
   };
 
@@ -289,6 +352,12 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
             }}
             onFocus={() => !inputDisabled && setOpen(true)}
             onKeyDown={handleKeyDown}
+            onCompositionStart={() => {
+              isComposingRefGlobal.current = true;
+            }}
+            onCompositionEnd={() => {
+              isComposingRefGlobal.current = false;
+            }}
             placeholder={placeholder}
             disabled={inputDisabled}
             role='combobox'


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

[입력창 오류 수정 시연 ](https://github.com/user-attachments/assets/b7d38c6f-83de-44ef-94a0-cc7a99725ea7)
죄송합니다; 어제부터 그냥 gif 파일을 올리면 보이지가 않아서 또 다시 링크로 걸어드리게 되었습니다.

- **존재하는 콘텐츠의 이름을 그대로 적고 엔터를 쳐도 드롭다운 최상단의 콘텐츠가 입력되던 버그를 수정했습니다.**
- **이제는 해당 콘텐츠의 이름을 적고 엔터를 누를 시 해당 콘텐츠가 선택되어 비교 입력창에 들어갑니다.**

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위
src/features/compare/components/CompareSelect.tsx: 문자열 비교 유틸 추가, handleKeyDown 에서 포커스 처리 부분 수정
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
