### PR TITLE
[HOY-163]refactor:최신 데이터 기준으로 비교 가능 기능 추가, 더블 클릭 방지(김인)

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -4,6 +4,7 @@
 import { toast } from 'react-toastify';
 
 import { useCompareStore } from '@/shared/stores/useCompareStore';
+import { selectA, selectB, selectInFlight } from '@/shared/stores/useCompareStoreSelectors';
 
 import CompareButton from '../../features/compare/components/CompareButton';
 import CompareResult from '../../features/compare/components/CompareResult';
@@ -35,10 +36,11 @@ const toastByReason = (
 };
 
 const ComparePage = () => {
-  const a = useCompareStore((s) => s.a);
-  const b = useCompareStore((s) => s.b);
+  const a = useCompareStore(selectA);
+  const b = useCompareStore(selectB);
   const trySetA = useCompareStore((s) => s.trySetA);
   const trySetB = useCompareStore((s) => s.trySetB);
+  const inFlight = useCompareStore(selectInFlight);
 
   return (
     <main className='mx-auto max-w-4xl p-[24px]'>
@@ -71,6 +73,7 @@ const ComparePage = () => {
         {/* 비교 버튼: 모바일에선 3번째 아이템으로 아래, md 이상에선 3번째 컬럼 오른쪽 정렬 */}
         <CompareButton
           className='justify-self-start md:justify-self-end'
+          disabled={inFlight}
           onResult={(ok, reason) => {
             if (!ok && reason) toast.info(reason);
           }}

--- a/src/shared/stores/useCompareStoreSelectors.ts
+++ b/src/shared/stores/useCompareStoreSelectors.ts
@@ -1,0 +1,20 @@
+// 전체 상태 구독 상황 등 대비 안전하게 사용하기 위한 CompareState 표준 셀렉터 유틸들
+import type { CompareState } from '@/shared/stores/useCompareStore';
+
+export const selectA = (state: CompareState) => state.a;
+export const selectB = (state: CompareState) => state.b;
+export const selectRequested = (state: CompareState) => state.requested;
+export const selectRequestTick = (state: CompareState) => state.requestTick;
+export const selectCanCompare = (state: CompareState) => state.canCompare();
+export const selectInvalidReason = (state: CompareState) => state.invalidReason();
+export const selectInFlight = (state: CompareState) => state.inFlight;
+
+/** 사용 팁
+ * 셀렉터가 객체를 반환해야 할 때는 shallow를 꼭 함께 사용하세요.
+ *  예시
+ *  import { shallow } from 'zustand/shallow';
+ *   const pair = useCompareStore(
+ *   (state) => ({ a: state.a, b: state.b }),
+ *   shallow,
+ *   );
+ */


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->
![최신 상태 대비 더블 클릭 방지 시연](https://github.com/user-attachments/assets/e9cf6789-1a84-41be-9569-f74b9c31c602)

## ✏️ 작업 내용 (📷 스크린샷•동영상)

- **비교 등록된 콘텐츠도 최신 데이터를 기준으로 비교되도록 수정했습니다.**
- **비교하기 버튼 클릭 시 서버에서 데이터 최신화 + 재연결시 자동 최신화(보조) 전략을 사용했습니다.**
- **불필요한 중복 요청을 막고자 비교하기 버튼에 더블 클릭 방지를 적용했습니다.** 

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위

src/shared/stores/useCompareStore.ts: 데이터 최신화 로직 추가
src/shared/stores/useCompareStoreSelectors.ts: 새로운 파일. 비교상태 표준 셀렉터 유틸 모음 추가. 편의성 증가 및 다른 곳에서 안전하게 import 가능하도록 하기 위해서
src/app/compare/page.tsx: 표준 셀렉터 유틸 import하게 수정, 비교하기 버튼 더블 클릭 방지
src/features/compare/components/CompareResult.tsx: stale값 조정 및 최신화 로직 적용


<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항
**현재 더블 클릭 방지는 체크했으나 비교 선택된 값들이 실제로 최신 데이터 기반으로 비교가 진행되는지는 3차 QA과정에서 확실하게 검증할 수 있을 것 같습니다.**
<!-- 리뷰어와 논의하고 싶은 부분 -->
