### PR TITLE
[Hoy 168] fix: (QA 수정사항) 비교 입력창 드롭다운 정렬 기준 수정 및 개수 제한(김인)

### DIFF
--- a/src/features/compare/components/CompareSelect.tsx
+++ b/src/features/compare/components/CompareSelect.tsx
@@ -41,6 +41,8 @@ export type CompareSelectProps = {
 
 // 사용자가 입력한 값(query)을 DEBOUNCE_MS(ms기준) 기다린 후 debounced에 반영
 const DEBOUNCE_MS = 150;
+// 드롭다운에 뜰 콘텐츠 수 제한
+const MAX_DROPDOWN_CONTENTS = 5;
 
 // 문자열 비교 유틸: 공백/대소문자/유니코드 정규화 등을 정리해서 완전 일치 판정 신뢰도 높임
 const normalizeForExactMatch = (input: string, locale: string = 'ko-KR'): string =>
@@ -125,10 +127,9 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
     const comparator = createQueryComparator<CompareCandidate>(debounced, {
       getText: (item) => item.name, // 비교 기준 텍스트
       isDisabled: (item) => Boolean(item.disabled), // 선택 불가 항목은 아래로
-      // normalizer: normalizeForCompare,     // ← 정규화 로직도 필요할 시 추가
     });
 
-    return [...serverOptions].sort(comparator);
+    return [...serverOptions].sort(comparator).slice(0, MAX_DROPDOWN_CONTENTS);
   }, [debounced, serverOptions]);
 
   // Chip이 있을 때 입력/검색 비활성

--- a/src/shared/utils/querySort.ts
+++ b/src/shared/utils/querySort.ts
@@ -1,8 +1,7 @@
 // 공용 입력 검색시 정렬 함수
 /**
- * 입력 쿼리(query)와 항목 텍스트의 일치도를 기준으로
- * "완전 일치 > 접두 일치 > 포함 일치 > 그 외" 순서로 정렬하는 비교 함수입니다.
- * querySort의 주 책임은 항목 배열을 쿼리 기반으로 정렬하는 것이라고 생각하기에 정규화 담당 함수인 normalize를 적용하진 않았습니다.
+ * 입력 쿼리(query)와 항목 텍스트의 일치도를 기준으로 완전 일치 > 접두 일치 > 포함 일치 > 그 외 순서로 정렬하는 비교 함수입니다.
+ * querySort의 주 책임은 항목 배열을 쿼리 기반으로 정렬하는 것이라고 생각하기에 정규화 담당 함수인 normalize를 적용하진 않았습니다.(둘다 적용 가능)
  */
 
 export type Normalizer = (text: string) => string;
@@ -24,7 +23,9 @@ export interface QuerySortOptions<T> {
   normalizer?: Normalizer;
 }
 
-/** 기본 정규화: 유니코드 NFKC → trim → 소문자화 */
+/** 기본 정규화: 유니코드 NFKC → trim → 소문자화
+ * 더 엄격한 정규화는 normalize 적용
+ */
 function normalizeTextDefault(text: string, locale: string = 'ko-KR'): string {
   return text.normalize('NFKC').trim().toLocaleLowerCase(locale);
 }
@@ -37,7 +38,7 @@ enum MatchPriority {
   None = 3, // 불일치
 }
 
-/** 항목 텍스트와 쿼리의 매칭 우선순위를 계산합니다. */
+/** 항목 텍스트와 쿼리의 매칭 우선순위를 계산 */
 function computeMatchPriority(
   itemText: string,
   query: string,
@@ -58,11 +59,11 @@ function computeMatchPriority(
 }
 
 /**
- * 주어진 쿼리에 대해 Array.sort에 전달할 비교 함수를 생성합니다.
+ * 주어진 쿼리에 대해 Array.sort에 전달할 비교 함수를 생성
  *
  * 정렬 규칙:
  *  1) disabled(선택 불가) 항목은 항상 아래
- *  2) 매칭 우선순위: 완전 > 접두 > 포함 > 불일치
+ *  2) 매칭 우선순위: 완전 일치 > 접두 일치 > 포함 일치 > 불일치
  *  3) 사용자 제공 tieBreaker가 있으면 적용
  *  4) 텍스트 길이(짧을수록 위)
  *  5) localeCompare


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)
![드롭다운 정렬 기준 수정 및 개수 제한 시연](https://github.com/user-attachments/assets/31110f46-1c7e-4354-81c5-2a9b499a11b7)

-  **비교 입력창 드롭다운이 서버에서 내려준 순서를 따라가서 UX와의 차이가 나던 부분을 수정했습니다.**
-  **매칭 우선순위를 완전 일치,  접두 일치,  포함 일치,  불일치 순위로 조정했습니다.**
-  **해당 과정에서 입력 검색시 정렬 함수를 공용 유틸 함수로 빼뒀습니다.**
- **비교 입력창 드롭다운에 5개로 개수 제한을 걸어서 단어 하나만 입력해도 무수히 많은 연관 콘텐츠가 스크롤로 내려오던 문제를 수정했습니다.**

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위
src/shared/utils/querySort.ts: 새로 추가된 파일. 검색 입력시 드롭다운의 정렬 기준 추가
src/features/compare/components/CompareSelect.tsx: 정렬 기준 수정, 드롭다운 개수 제한
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항
AddContentModal에서도 정렬 기준을 고민하시던 거 같아서 유진님도 리뷰어에 등록해두었습니다. 공용 유틸 함수 체크해보시고 사용을 고려해주시면 감사하겠습니다!
<!-- 리뷰어와 논의하고 싶은 부분 -->
