### PR TITLE
[Hoy-171] fix: (QA 수정 사항) 유저 전환 시 로컬스토리지 제대로 반영 안되던 문제 수정(김인)

### DIFF
--- a/src/features/compare/components/CompareSelect.tsx
+++ b/src/features/compare/components/CompareSelect.tsx
@@ -278,7 +278,7 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
     if (e.key === 'Enter' && !composing) {
       e.preventDefault();
 
-      // ★ 변경: 우선순위 — 1) 완전 일치 2) 활성 항목 3) 첫 항목(옵션)
+      // 우선순위 — 1) 완전 일치 2) 활성 항목 3) 첫 항목(옵션)
       const exactIdx = findExactMatchIndex(filtered, query);
       if (exactIdx !== -1 && !filtered[exactIdx]?.disabled) {
         handleSelect(filtered[exactIdx]);
@@ -373,6 +373,14 @@ const CompareSelect = forwardRef<HTMLInputElement, CompareSelectProps>(function 
             aria-expanded={open}
             aria-controls={listboxId}
             aria-autocomplete='list'
+            // 브라우저 자동완성(저장된 입력/주소록/폼 자동채움) 차단
+            autoComplete='off'
+            // 브라우저 철자 검사/교정 끄기
+            spellCheck={false}
+            autoCorrect='off'
+            autoCapitalize='off'
+            // 텍스트 일반 입력 의도 전달
+            inputMode='text'
             className={cn(
               'h-full w-full rounded-xl bg-transparent text-white outline-none',
               'placeholder:text-gray-600',

--- a/src/features/compare/types/compareTypes.ts
+++ b/src/features/compare/types/compareTypes.ts
@@ -1,4 +1,4 @@
-// 비교하기 페이지에서 쓰이는 타입들
+// 비교하기 페이지에서 쓰이는 타입들 색상, 비교 문구 등 관리
 
 // 승자 텍스트 색상 상수화
 export const WINNER_TEXT_COLOR = {
@@ -14,7 +14,7 @@ export type WinnerCode = 'A' | 'B' | 'TIE';
 export const WINNER_CONFIG: Record<WinnerCode, { text: string; color: string }> = {
   A: { text: '콘텐츠 1 우세', color: WINNER_TEXT_COLOR.A },
   B: { text: '콘텐츠 2 우세', color: WINNER_TEXT_COLOR.B },
-  TIE: { text: '무승부', color: WINNER_TEXT_COLOR.TIE },
+  TIE: { text: '동일', color: WINNER_TEXT_COLOR.TIE },
 } as const;
 
 // 사용자가 드롭다운에서 고르는 “후보” 타입 (Select 전용)

--- a/src/shared/stores/useCompareStore.ts
+++ b/src/shared/stores/useCompareStore.ts
@@ -6,8 +6,9 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
-import type { CompareCandidate } from '../../features/compare/types/compareTypes';
+import { readCurrentUserId, subscribeUserId } from './userIdSource';
 
+import type { CompareCandidate } from '../../features/compare/types/compareTypes';
 /** 유틸/타입 */
 
 /** 동일 아이템 선택 방지 + 카테고리 규칙 */
@@ -108,53 +109,9 @@ const isSameCategory = (a: CompareCandidate | null, b: CompareCandidate | null) 
 /** 추후 스키마 변경 대비 버전 - V2로 변경 categoryId 없는 과거 저장본 방어 */
 const PERSIST_VERSION = 2;
 
-/**
- * 현재 로그인한 유저 id를 userStore의 persist 값(auth-storage)에서 읽어옵니다.
- * - auth-storage 포맷은 zustand persist 기본 형태: { state: {...}, version: N }
- * - user.id 경로가 바뀌면 이 함수만 수정
- * - 값이 없거나 파싱 실패 시 null 반환.
- */
-function getCurrentUserIdFromAuthStorage(): string | null {
-  try {
-    const raw = localStorage.getItem('auth-storage');
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    return parsed?.state?.user?.id ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /** compare persist 기본 키(로그인 상태에서만 저장, 비로그인 시 저장 안 함) */
 const BASE_KEY = 'compare-storage';
 
-/** 추가: userId 변경 감지 & 동기화 유틸 (모듈 스코프), 마지막으로 확인한 userId를 기억하기 위함 */
-let lastUserId: string | null | undefined = undefined;
-
-// 현재 auth-storage 기준 userId를 읽어와, 바뀌었으면 sync 실행
-function trySyncCompareOnUserChange() {
-  try {
-    const current = getCurrentUserIdFromAuthStorage();
-    if (lastUserId === current) return; // 변화 없음
-
-    lastUserId = current;
-
-    // zustand 스토어 액션 호출: B 유저 스냅샷 있으면 복원, 없으면 초기화
-    // (아래 useCompareStore 정의 이후에 바인딩되므로, 안전하게 microtask로 미룸)
-    queueMicrotask(() => {
-      try {
-        useCompareStore.getState().syncWithCurrentUser();
-      } catch (e) {
-        // 아직 스토어가 초기화 안 된 아주 이른 타이밍 대비
-        setTimeout(() => {
-          try {
-            useCompareStore.getState().syncWithCurrentUser();
-          } catch {}
-        }, 0);
-      }
-    });
-  } catch {}
-}
 /**
  * 커스텀 스토리지 어댑터
  * - zustand의 storage 인터페이스(getItem/setItem/removeItem)를 구현해서
@@ -163,62 +120,32 @@ function trySyncCompareOnUserChange() {
  */
 const namespacedStorage = {
   getItem: (name: string) => {
-    const userId = getCurrentUserIdFromAuthStorage();
-    if (!userId) return null;
-    return localStorage.getItem(`${BASE_KEY}:${userId}`);
+    // SSR 방어용
+    if (typeof window === 'undefined') return null;
+
+    // 1) 스토어에서 userId를 읽고, 실패 시 로컬 폴백 (헬퍼가 수행)
+    const userId = readCurrentUserId();
+    // 2) 비로그인/유저 미확정 상태면 persist를 비활성화(읽지 않음)
+    if (userId == null) return null;
+
+    // 3) 키는 반드시 문자열화해서 네임스페이스 구성
+    const key = `${BASE_KEY}:${String(userId)}`;
+    return localStorage.getItem(key);
   },
   setItem: (name: string, value: string) => {
-    const userId = getCurrentUserIdFromAuthStorage();
-    const key = userId ? `${BASE_KEY}:${userId}` : '(no user)';
-    try {
-      const parsed = JSON.parse(value);
-      // ★ a/b가 null로 저장될 때만 로그
-      if (parsed?.state?.a === null && parsed?.state?.b === null) {
-        // console.warn('[compare:setItem NULL SAVE]', { key, value: parsed });
-        // console.trace('[compare: NULL save stack]');
-      } else {
-      }
-    } catch {}
-    if (!userId) return; // 비로그인 상태에선 저장 안 함
-    localStorage.setItem(`${BASE_KEY}:${userId}`, value);
+    if (typeof window === 'undefined') return;
+    const userId = readCurrentUserId();
+    // 비로그인/유저 미확정 상태면 저장 금지 (정책 유지)
+    if (userId == null) return;
+
+    const key = `${BASE_KEY}:${String(userId)}`;
+
+    localStorage.setItem(key, value);
   },
   removeItem: (name: string) => {
     //의도치 않은 시점에 유저 키가 삭제되는 문제 예방하기 위해 no-op 처리
   },
 };
-
-/** 추가: 같은 탭에서 auth-storage가 갱신될 때를 감지하기 위한 후킹
-   - localStorage.setItem('auth-storage', ...) 이후 즉시 동기화
-   - 다른 키에는 영향 없음
- */
-(() => {
-  if (typeof window === 'undefined') return;
-
-  const origSetItem = localStorage.setItem.bind(localStorage);
-
-  localStorage.setItem = function (key: string, value: string) {
-    origSetItem(key, value);
-    if (key === 'auth-storage') {
-      // 로그인/로그아웃/유저전환 직후, 같은 탭에서도 확실히 감지
-      trySyncCompareOnUserChange();
-    }
-  };
-
-  // 다른 탭에서 auth-storage가 바뀐 경우(브라우저 표준 storage 이벤트)
-  window.addEventListener('storage', (e) => {
-    if (e.key === 'auth-storage') {
-      trySyncCompareOnUserChange();
-    }
-  });
-
-  // 탭 포커스나 가시성 전환 시에도 한 번 동기화 (백그라운드에서 바뀐 경우 대비)
-  const onWake = () => trySyncCompareOnUserChange();
-  window.addEventListener('focus', onWake);
-  document.addEventListener('visibilitychange', onWake);
-
-  // 초기 1회 동기화 (앱 로드 시 현재 유저 스냅샷 반영)
-  queueMicrotask(trySyncCompareOnUserChange);
-})();
 
 /* zustand store 부분 */
 
@@ -361,21 +288,17 @@ export const useCompareStore = create<CompareState>()(
 
         return null;
       },
-      /**
-       * - 유저 전환 시: 로그인 상태면 해당 유저 키에서 복원, 아니면 메모리 초기화
-       * - 이제 직접 JSON 파싱하여 set()하지 않고,zustand persist의 rehydrate 경로를 최우선으로 사용
-       * - (migrate/partialize/version을 그대로 따르기 때문에 안전)
-       */
+
       syncWithCurrentUser: () => {
         try {
-          const userId = getCurrentUserIdFromAuthStorage();
+          const userId = readCurrentUserId();
           // 1) 로그아웃 상태: 메모리만 초기화.
           if (!userId) {
             set({ a: null, b: null, requested: false, requestTick: 0, inFlight: false });
             return;
           }
 
-          const key = `${BASE_KEY}:${userId}`;
+          const key = `${BASE_KEY}:${String(userId)}`;
           const raw = localStorage.getItem(key);
 
           // 다음 틱에서 처리 → namespacedStorage가 '변경된 userId'로 읽도록 보장
@@ -421,17 +344,16 @@ export const useCompareStore = create<CompareState>()(
 
       // 명시적 삭제 액션: 정말로 현재 유저의 compare-storage를 지워야 할 때만 사용
       wipeCurrentUserStorage: () => {
-        const userId = getCurrentUserIdFromAuthStorage();
+        const userId = readCurrentUserId();
         if (!userId) return;
-        const key = `${BASE_KEY}:${userId}`;
+        const key = `${BASE_KEY}:${String(userId)}`;
         localStorage.removeItem(key);
       },
     }),
 
     {
       /**
-       * name은 의미상으로만 사용됩니다.
-       * 실제 저장 키는 namespacedStorage가 `compare-storage:<userId>`로 바꿔서 씁니다.
+       * name은 논리적 이름일 뿐, 실제 저장 키는 namespacedStorage가 `${BASE_KEY}:${userId}` 형태로 관리합니다.
        */
       name: BASE_KEY,
       version: PERSIST_VERSION,
@@ -473,3 +395,50 @@ export const useCompareStore = create<CompareState>()(
     },
   ),
 );
+
+declare global {
+  /** 브라우저 전역(window)에 구독 해제 핸들러를 보관 */
+  interface Window {
+    compareUserSyncUnsub?: () => void;
+  }
+  /** Next/Vite 등 개발환경에서만 존재할 수 있는 HMR API 타입 */
+  interface ImportMeta {
+    hot?: { dispose(cb: () => void): void };
+  }
+}
+
+if (typeof window !== 'undefined') {
+  // 1) 기존 구독이 있으면 해제 (HMR/중복 방지)
+  if (window.compareUserSyncUnsub) {
+    window.compareUserSyncUnsub();
+  }
+
+  // 2) 새 구독 등록: userId가 바뀌면 compare 스토어 동기화
+  const unsubscribe = subscribeUserId(() => {
+    queueMicrotask(() => {
+      try {
+        useCompareStore.getState().syncWithCurrentUser();
+      } catch {
+        // 초기 경합 상황 대비해 한 틱 더 미룸
+        setTimeout(() => {
+          try {
+            useCompareStore.getState().syncWithCurrentUser();
+          } catch {
+            /* 초기 마운트 경합 등을 위한 noop */
+          }
+        }, 0);
+      }
+    });
+  });
+
+  // 3) 전역 슬롯에 저장(동일 탭 HMR에도 1개만 유지)
+  window.compareUserSyncUnsub = unsubscribe;
+
+  // 4) HMR 정리: 모듈 교체 시 구독 해제
+  if (import.meta.hot) {
+    import.meta.hot.dispose(() => {
+      window.compareUserSyncUnsub?.();
+      window.compareUserSyncUnsub = undefined;
+    });
+  }
+}

--- a/src/shared/stores/useCompareStore.ts
+++ b/src/shared/stores/useCompareStore.ts
@@ -116,14 +116,11 @@ const PERSIST_VERSION = 2;
  */
 function getCurrentUserIdFromAuthStorage(): string | null {
   try {
-    console.log('getCurrentUserIdFrom...');
     const raw = localStorage.getItem('auth-storage');
-    console.log('raw', raw);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
     return parsed?.state?.user?.id ?? null;
-  } catch (e) {
-    console.log(e);
+  } catch {
     return null;
   }
 }
@@ -167,8 +164,6 @@ function __trySyncCompareOnUserChange() {
 const namespacedStorage = {
   getItem: (_name: string) => {
     const userId = getCurrentUserIdFromAuthStorage();
-    console.log(userId, 'getitem');
-    console.log(localStorage.getItem(`${BASE_KEY}:${userId}`), 'getitem');
     if (!userId) return null;
     return localStorage.getItem(`${BASE_KEY}:${userId}`);
   },
@@ -177,7 +172,6 @@ const namespacedStorage = {
     const key = userId ? `${BASE_KEY}:${userId}` : '(no user)';
     try {
       const parsed = JSON.parse(value);
-      console.log('setItem', key, parsed);
       // ★ a/b가 null로 저장될 때만 로그
       if (parsed?.state?.a === null && parsed?.state?.b === null) {
         // console.warn('[compare:setItem NULL SAVE]', { key, value: parsed });

--- a/src/shared/stores/userIdSource.ts
+++ b/src/shared/stores/userIdSource.ts
@@ -1,0 +1,62 @@
+// useCompareStore에서 useStore를 단뱡향 참조하기 위한 헬퍼 모듈
+
+import { useUserStore } from '@/shared/stores/userStore';
+
+export type UserId = number;
+
+/** 1) useUserStore userId 읽기 */
+export function readUserIdFromStore(): UserId | null {
+  try {
+    // 현재 시점의 user 스토어 상태 스냅샷
+    const userStoreState = useUserStore.getState();
+    return (userStoreState.user?.id ?? null) as UserId | null;
+  } catch {
+    return null;
+  }
+}
+
+/** 2) 폴백: persist된 auth-storage에서 userId 읽기(읽기 전용) */
+export function readUserIdFromAuthStorage(): UserId | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    // useUserStore의 persist name이 'auth-storage'이므로 동일 키 사용
+    const raw = localStorage.getItem('auth-storage');
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return (parsed?.state?.user?.id ?? null) as UserId | null;
+  } catch {
+    return null;
+  }
+}
+
+/**  userStore 스토어 우선 실패 시 로컬 폴백 */
+export function readCurrentUserId(): UserId | null {
+  const fromStore = readUserIdFromStore();
+  return fromStore ?? readUserIdFromAuthStorage();
+}
+
+/**
+ * userId 변경 구독 (미들웨어 없는 환경에서도 작동하는 안전 버전)
+ * - 단일 인자 subscribe(listener)만 사용
+ * - 내부에서 prev/next를 직접 비교해 변할 때만 onChange 호출
+ * - 반환: 구독 해제 함수
+ */
+export function subscribeUserId(
+  onChange: (nextUserId: UserId | null, prevUserId: UserId | null) => void,
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  let prevUserId: UserId | null = readUserIdFromStore();
+
+  return useUserStore.subscribe((nextState) => {
+    const nextUserId: UserId | null = (nextState?.user?.id ?? null) as UserId | null;
+
+    if (Object.is(nextUserId, prevUserId)) return;
+
+    const prev = prevUserId;
+    prevUserId = nextUserId;
+    onChange(nextUserId, prev);
+  });
+}


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)
![유저별 로컬스토리지 문제 수정 시연](https://github.com/user-attachments/assets/03960126-c113-48d8-89a9-d41c079c999b)

- **여러 계정으로 로그인/로그아웃시 로컬 스토리지가 날아가는 버그라고 생각했는데 _사실은 zustand storage value 갱신 문제_ 였습니다.**
- **userId가 바뀐다고 해서 해당 저장값(value)가 저절로 바뀌는 것이 아니었고 유저가 바뀔 때에 해당 value도 재수화(rehydrate) 과정을 거치도록 수정해서 문제를 해결했습니다.**
- **무승부 대신 '동일'이라는 문구로 변경했습니다.**
- **브라우저에서 자동완성을 못 시키도록 변경했습니다. (윈도우 차원의 자동완성은 막지 못한다고 합니다...)**

- **정환님 피드백 사항을 반영하여 user 데이터의 원본이 있는 userStore를 먼저 참조하는 방법으로 수정을 했습니다.**

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위
src/shared/stores/useCompareStore.ts: value값 재수화(rehydrate) 로직을 추가하여 유저 전환에 따라 해당 유저의 저장된 비교 결과 값이 로컬스토리지에 잘 유지되도록 수정했습니다.
src/features/compare/components/CompareSelect.tsx: 브라우저 차원의 자동완성 기능을 막았습니다.
src/features/compare/types/compareTypes.ts:: 주석 수정 및 단순 문구 수정
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
