### PR TITLE
[HOY-132] feat: 탭 리스트 api 연결 / 무한스크롤 적용/ 마이페이지 오류 수정 (배혜민)

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -72,7 +72,7 @@ const mapReviewed = (it: ReviewedItem): ContentItem => {
   const selfRating = getProp<number>(it, 'rating');
   return {
     contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 상품',
+    title: p?.name ?? p?.title ?? '이름 없는 콘텐츠',
     contentImage: toSrc(p?.image ?? null),
     favoriteCount: Number(p?.favoriteCount ?? 0),
     reviewCount: Number(p?.reviewCount ?? 0),
@@ -84,7 +84,7 @@ const mapCreated = (it: CreatedItem): ContentItem => {
   const p = getProductLike(it);
   return {
     contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 상품',
+    title: p?.name ?? p?.title ?? '이름 없는 콘텐츠',
     contentImage: toSrc(p?.image ?? null),
     favoriteCount: Number(p?.favoriteCount ?? 0),
     reviewCount: Number(p?.reviewCount ?? 0),
@@ -96,7 +96,7 @@ const mapFavorite = (it: FavoriteItem): ContentItem => {
   const p = getProductLike(it);
   return {
     contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 상품',
+    title: p?.name ?? p?.title ?? '이름 없는 콘텐츠',
     contentImage: toSrc(p?.image ?? null),
     favoriteCount: Number(p?.favoriteCount ?? 0),
     reviewCount: Number(p?.reviewCount ?? 0),

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -11,6 +11,7 @@ import ProfileTabsSection from '@/features/mypage/components/ProfileTabsSection'
 import ProfileUpdateModal from '@/features/mypage/components/ProfileUpdateModal';
 import { TEAM_ID } from '@/shared/constants/constants';
 import { useUserStore } from '@/shared/stores/userStore';
+import { mapToContentItem } from '@/shared/utils/mapToContentItem';
 
 import { useMe } from '../../../openapi/queries/queries';
 
@@ -67,43 +68,12 @@ const getProductLike = (x: unknown): ProductLike | undefined => {
   return undefined;
 };
 
-const mapReviewed = (it: ReviewedItem): ContentItem => {
-  const p = getProductLike(it);
-  const selfRating = getProp<number>(it, 'rating');
-  return {
-    contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 콘텐츠',
-    contentImage: toSrc(p?.image ?? null),
-    favoriteCount: Number(p?.favoriteCount ?? 0),
-    reviewCount: Number(p?.reviewCount ?? 0),
-    rating: Number(selfRating ?? p?.averageRating ?? p?.rating ?? 0),
-  };
-};
+const mapReviewed = (it: ReviewedItem): ContentItem =>
+  mapToContentItem(it, { preferSelfRating: true });
 
-const mapCreated = (it: CreatedItem): ContentItem => {
-  const p = getProductLike(it);
-  return {
-    contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 콘텐츠',
-    contentImage: toSrc(p?.image ?? null),
-    favoriteCount: Number(p?.favoriteCount ?? 0),
-    reviewCount: Number(p?.reviewCount ?? 0),
-    rating: Number(p?.averageRating ?? p?.rating ?? 0),
-  };
-};
+const mapCreated = (it: CreatedItem): ContentItem => mapToContentItem(it);
 
-const mapFavorite = (it: FavoriteItem): ContentItem => {
-  const p = getProductLike(it);
-  return {
-    contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 콘텐츠',
-    contentImage: toSrc(p?.image ?? null),
-    favoriteCount: Number(p?.favoriteCount ?? 0),
-    reviewCount: Number(p?.reviewCount ?? 0),
-    rating: Number(p?.averageRating ?? p?.rating ?? 0),
-  };
-};
-
+const mapFavorite = (it: FavoriteItem): ContentItem => mapToContentItem(it);
 export default function MyPage() {
   // 내 정보
   const { data: meData, isLoading: isMeLoading } = useMe(

--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -10,6 +10,7 @@ import ProfileTabsSection from '@/features/mypage/components/ProfileTabsSection'
 import { useFollowMutations } from '@/features/user/hooks/useFollowMutaion';
 import { TEAM_ID, PATH_OPTION } from '@/shared/constants/constants';
 import { useUserStore } from '@/shared/stores/userStore';
+import { mapToContentItem } from '@/shared/utils/mapToContentItem';
 
 import { useUserDetail } from '../../../../openapi/queries/queries';
 
@@ -58,7 +59,6 @@ const getProp = <T,>(obj: unknown, key: string): T | undefined => {
 };
 
 const getProductLike = (x: unknown): ProductLike | undefined => {
-  // 응답이 { product: {...} } 이면 product, 아니면 자기 자신
   const maybeProduct = getProp<unknown>(x, 'product');
   const base = maybeProduct ?? x;
   const r = asRecord(base);
@@ -68,42 +68,12 @@ const getProductLike = (x: unknown): ProductLike | undefined => {
   return undefined;
 };
 
-const mapReviewed = (it: ReviewedItem): ContentItem => {
-  const p = getProductLike(it);
-  const selfRating = getProp<number>(it, 'rating');
-  return {
-    contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 상품',
-    contentImage: toSrc(p?.image ?? null), // ✅ 항상 string
-    favoriteCount: Number(p?.favoriteCount ?? 0),
-    reviewCount: Number(p?.reviewCount ?? 0),
-    rating: Number(selfRating ?? p?.averageRating ?? p?.rating ?? 0),
-  };
-};
+const mapReviewed = (it: ReviewedItem): ContentItem =>
+  mapToContentItem(it, { preferSelfRating: true });
 
-const mapCreated = (it: CreatedItem): ContentItem => {
-  const p = getProductLike(it);
-  return {
-    contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 상품',
-    contentImage: toSrc(p?.image ?? null),
-    favoriteCount: Number(p?.favoriteCount ?? 0),
-    reviewCount: Number(p?.reviewCount ?? 0),
-    rating: Number(p?.averageRating ?? p?.rating ?? 0),
-  };
-};
+const mapCreated = (it: CreatedItem): ContentItem => mapToContentItem(it);
 
-const mapFavorite = (it: FavoriteItem): ContentItem => {
-  const p = getProductLike(it);
-  return {
-    contentId: p?.id ?? 0,
-    title: p?.name ?? p?.title ?? '이름 없는 상품',
-    contentImage: toSrc(p?.image ?? null),
-    favoriteCount: Number(p?.favoriteCount ?? 0),
-    reviewCount: Number(p?.reviewCount ?? 0),
-    rating: Number(p?.averageRating ?? p?.rating ?? 0),
-  };
-};
+const mapFavorite = (it: FavoriteItem): ContentItem => mapToContentItem(it);
 
 export default function UserPage() {
   const { userId } = useParams<{ userId: string }>();

--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -2,34 +2,108 @@
 
 import { useParams } from 'next/navigation';
 
-import { useInfiniteQuery } from '@tanstack/react-query';
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 
-import VirtualizedContentGrid from '@/features/mainPage/components/VirtualizedContentGrid';
 import ActivityCard from '@/features/mypage/components/activityCard';
 import ProfileCard from '@/features/mypage/components/ProfileCard';
-import ProfileTabs from '@/features/mypage/components/ProfileTabs';
-import { fetchDummyPage } from '@/features/mypage/mock/dummyPager';
+import ProfileTabsSection from '@/features/mypage/components/ProfileTabsSection';
 import { useFollowMutations } from '@/features/user/hooks/useFollowMutaion';
 import { TEAM_ID, PATH_OPTION } from '@/shared/constants/constants';
 import { useUserStore } from '@/shared/stores/userStore';
 
 import { useUserDetail } from '../../../../openapi/queries/queries';
 
-import type { UserDetailDefaultResponse } from '../../../../openapi/queries/common';
+import type {
+  UserDetailDefaultResponse,
+  ListUserReviewedProductsDefaultResponse as ReviewedResp,
+  ListUserCreatedProductsDefaultResponse as CreatedResp,
+  ListUserFavoriteProductsDefaultResponse as FavoriteResp,
+} from '../../../../openapi/queries/common';
 import type { ContentItem } from '@/shared/types/content';
 
-type TabKey = 'reviews' | 'items' | 'wishlist';
+const toSrc = (url?: string | null): string =>
+  url && url.trim() !== '' ? url : '/images/ProfileFallbackImg.png';
 
 const mapUserToCard = (userDetail?: UserDetailDefaultResponse) => ({
   name: userDetail?.nickname ?? '',
-  avatarSrc: userDetail?.image ?? '',
+  avatarSrc: toSrc(userDetail?.image ?? null),
   bio: userDetail?.description ?? '',
-  followers: (userDetail?.followersCount ?? 0) as number,
-  following: (userDetail?.followeesCount ?? 0) as number,
+  followers: Number(userDetail?.followersCount ?? 0),
+  following: Number(userDetail?.followeesCount ?? 0),
   isMe: false,
   isFollowing: Boolean(userDetail?.isFollowing),
 });
+
+type ReviewedItem = NonNullable<ReviewedResp>['list'][number];
+type CreatedItem = NonNullable<CreatedResp>['list'][number];
+type FavoriteItem = NonNullable<FavoriteResp>['list'][number];
+
+type ProductLike = {
+  id: number;
+  name?: string;
+  title?: string;
+  image?: string | null;
+  favoriteCount?: number;
+  reviewCount?: number;
+  averageRating?: number;
+  rating?: number;
+};
+
+const asRecord = (x: unknown): Record<string, unknown> | null =>
+  x && typeof x === 'object' ? (x as Record<string, unknown>) : null;
+
+const getProp = <T,>(obj: unknown, key: string): T | undefined => {
+  const r = asRecord(obj);
+  return r && key in r ? (r[key] as T) : undefined;
+};
+
+const getProductLike = (x: unknown): ProductLike | undefined => {
+  // 응답이 { product: {...} } 이면 product, 아니면 자기 자신
+  const maybeProduct = getProp<unknown>(x, 'product');
+  const base = maybeProduct ?? x;
+  const r = asRecord(base);
+  if (r && 'id' in r && typeof r.id === 'number') {
+    return r as unknown as ProductLike;
+  }
+  return undefined;
+};
+
+const mapReviewed = (it: ReviewedItem): ContentItem => {
+  const p = getProductLike(it);
+  const selfRating = getProp<number>(it, 'rating');
+  return {
+    contentId: p?.id ?? 0,
+    title: p?.name ?? p?.title ?? '이름 없는 상품',
+    contentImage: toSrc(p?.image ?? null), // ✅ 항상 string
+    favoriteCount: Number(p?.favoriteCount ?? 0),
+    reviewCount: Number(p?.reviewCount ?? 0),
+    rating: Number(selfRating ?? p?.averageRating ?? p?.rating ?? 0),
+  };
+};
+
+const mapCreated = (it: CreatedItem): ContentItem => {
+  const p = getProductLike(it);
+  return {
+    contentId: p?.id ?? 0,
+    title: p?.name ?? p?.title ?? '이름 없는 상품',
+    contentImage: toSrc(p?.image ?? null),
+    favoriteCount: Number(p?.favoriteCount ?? 0),
+    reviewCount: Number(p?.reviewCount ?? 0),
+    rating: Number(p?.averageRating ?? p?.rating ?? 0),
+  };
+};
+
+const mapFavorite = (it: FavoriteItem): ContentItem => {
+  const p = getProductLike(it);
+  return {
+    contentId: p?.id ?? 0,
+    title: p?.name ?? p?.title ?? '이름 없는 상품',
+    contentImage: toSrc(p?.image ?? null),
+    favoriteCount: Number(p?.favoriteCount ?? 0),
+    reviewCount: Number(p?.reviewCount ?? 0),
+    rating: Number(p?.averageRating ?? p?.rating ?? 0),
+  };
+};
 
 export default function UserPage() {
   const { userId } = useParams<{ userId: string }>();
@@ -41,35 +115,6 @@ export default function UserPage() {
 
   const fm = useFollowMutations(uidNum, isLoggedIn ? meId : undefined);
   const followBtnDisabled = !isLoggedIn || fm.actionDisabled;
-
-  const [tab, setTab] = useState<TabKey>('reviews');
-  const {
-    data: pages,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    isLoading,
-  } = useInfiniteQuery({
-    queryKey: ['mypage', 'infinite', tab],
-    queryFn: ({ pageParam = 0 }) => fetchDummyPage({ cursor: pageParam, limit: 12 }),
-    initialPageParam: 0,
-    getNextPageParam: (last) => last.nextCursor ?? undefined,
-  });
-
-  const items: ContentItem[] = useMemo(
-    () =>
-      (pages?.pages ?? []).flatMap((p) =>
-        p.items.map((it) => ({
-          contentId: it.id,
-          title: it.title,
-          contentImage: it.image,
-          favoriteCount: it.favoriteCount,
-          reviewCount: it.reviewCount,
-          rating: it.rating,
-        })),
-      ),
-    [pages],
-  );
 
   const { data: userDetail, isLoading: isUserLoading } = useUserDetail(
     { ...PATH_OPTION, path: { ...PATH_OPTION.path, userId: uidNum } },
@@ -110,18 +155,12 @@ export default function UserPage() {
           />
         </div>
 
-        <ProfileTabs value={tab} onChange={setTab} />
-
-        <div className='mt-6 pb-[80px]'>
-          <VirtualizedContentGrid
-            items={items}
-            hasNextPage={!!hasNextPage}
-            fetchNextPage={fetchNextPage}
-            isLoading={isLoading || isFetchingNextPage}
-            itemHeightEstimate={276}
-            rowGap={16}
-          />
-        </div>
+        <ProfileTabsSection
+          userId={uidNum}
+          mapReviewed={mapReviewed}
+          mapCreated={mapCreated}
+          mapFavorite={mapFavorite}
+        />
       </div>
     </div>
   );

--- a/src/features/mypage/components/ProfileTabsSection.tsx
+++ b/src/features/mypage/components/ProfileTabsSection.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import React, { useMemo, useState } from 'react';
+
+import VirtualizedContentGrid from '@/features/mainPage/components/VirtualizedContentGrid';
+import ProfileTabs from '@/features/mypage/components/ProfileTabs';
+import { TEAM_ID } from '@/shared/constants/constants';
+
+import {
+  listUserReviewedProducts,
+  listUserCreatedProducts,
+  listUserFavoriteProducts,
+} from '../../../../openapi/requests/services.gen';
+
+import type {
+  ListUserReviewedProductsDefaultResponse as ReviewedResp,
+  ListUserCreatedProductsDefaultResponse as CreatedResp,
+  ListUserFavoriteProductsDefaultResponse as FavoriteResp,
+} from '../../../../openapi/queries/common';
+import type { ContentItem } from '@/shared/types/content';
+
+type TabKey = 'reviews' | 'items' | 'wishlist';
+
+type ReviewedItem = NonNullable<ReviewedResp>['list'][number];
+type CreatedItem = NonNullable<CreatedResp>['list'][number];
+type FavoriteItem = NonNullable<FavoriteResp>['list'][number];
+
+type Props = {
+  userId: number;
+  mapReviewed: (item: ReviewedItem) => ContentItem;
+  mapCreated: (item: CreatedItem) => ContentItem;
+  mapFavorite: (item: FavoriteItem) => ContentItem;
+};
+
+type SectionProps<T> = {
+  list: T[];
+  isLoading: boolean;
+  isError: boolean;
+  emptyText: string;
+  mapFn: (it: T) => ContentItem;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+};
+
+const SectionBlock = <T,>({
+  list,
+  isLoading,
+  isError,
+  emptyText,
+  mapFn,
+  hasNextPage,
+  fetchNextPage,
+}: SectionProps<T>) => {
+  if (isLoading && list.length === 0) return <p className='text-gray-400'>불러오는 중…</p>;
+  if (isError) return <p className='text-red-400'>불러오기에 실패했어요.</p>;
+  if (list.length === 0) return <p className='text-gray-400'>{emptyText}</p>;
+
+  const items = list.map(mapFn);
+  return (
+    <VirtualizedContentGrid
+      items={items}
+      hasNextPage={hasNextPage}
+      fetchNextPage={fetchNextPage}
+      isLoading={isLoading}
+      itemHeightEstimate={276}
+      rowGap={16}
+    />
+  );
+};
+
+export default function ProfileTabsSection({
+  userId,
+  mapReviewed,
+  mapCreated,
+  mapFavorite,
+}: Props) {
+  const [tab, setTab] = useState<TabKey>('reviews');
+
+  const fetchReviewed = async ({ pageParam }: { pageParam: number | null | undefined }) => {
+    const res = await listUserReviewedProducts({
+      path: { teamId: TEAM_ID as string, userId },
+      query: pageParam ? { cursor: pageParam } : undefined,
+    });
+    return res.data as ReviewedResp;
+  };
+
+  const fetchCreated = async ({ pageParam }: { pageParam: number | null | undefined }) => {
+    const res = await listUserCreatedProducts({
+      path: { teamId: TEAM_ID as string, userId },
+      query: pageParam ? { cursor: pageParam } : undefined,
+    });
+    return res.data as CreatedResp;
+  };
+
+  const fetchFavorite = async ({ pageParam }: { pageParam: number | null | undefined }) => {
+    const res = await listUserFavoriteProducts({
+      path: { teamId: TEAM_ID as string, userId },
+      query: pageParam ? { cursor: pageParam } : undefined,
+    });
+    return res.data as FavoriteResp;
+  };
+
+  const reviewedQ = useInfiniteQuery({
+    queryKey: ['user', userId, 'reviews'],
+    queryFn: fetchReviewed,
+    initialPageParam: null as number | null,
+    getNextPageParam: (last) => last?.nextCursor ?? undefined,
+    enabled: tab === 'reviews',
+    placeholderData: (prev) => prev,
+    staleTime: 30_000,
+  });
+
+  const createdQ = useInfiniteQuery({
+    queryKey: ['user', userId, 'items'],
+    queryFn: fetchCreated,
+    initialPageParam: null as number | null,
+    getNextPageParam: (last) => last?.nextCursor ?? undefined,
+    enabled: tab === 'items',
+    placeholderData: (prev) => prev,
+    staleTime: 30_000,
+  });
+
+  const favoriteQ = useInfiniteQuery({
+    queryKey: ['user', userId, 'wishlist'],
+    queryFn: fetchFavorite,
+    initialPageParam: null as number | null,
+    getNextPageParam: (last) => last?.nextCursor ?? undefined,
+    enabled: tab === 'wishlist',
+    placeholderData: (prev) => prev,
+    staleTime: 30_000,
+  });
+
+  const reviewedList: ReviewedItem[] =
+    reviewedQ.data?.pages?.flatMap((p) => (p ? p.list : [])) ?? [];
+
+  const createdList: CreatedItem[] = createdQ.data?.pages?.flatMap((p) => (p ? p.list : [])) ?? [];
+
+  const favoriteList: FavoriteItem[] =
+    favoriteQ.data?.pages?.flatMap((p) => (p ? p.list : [])) ?? [];
+
+  return (
+    <div className='w-full'>
+      <ProfileTabs value={tab} onChange={setTab} />
+
+      <div className='mt-6 pb-[80px]'>
+        {tab === 'reviews' && (
+          <SectionBlock
+            list={reviewedList}
+            isLoading={reviewedQ.isLoading || reviewedQ.isFetchingNextPage}
+            isError={!!reviewedQ.isError}
+            emptyText='리뷰가 없어요'
+            mapFn={mapReviewed}
+            hasNextPage={!!reviewedQ.hasNextPage}
+            fetchNextPage={() => reviewedQ.fetchNextPage()}
+          />
+        )}
+
+        {tab === 'items' && (
+          <SectionBlock
+            list={createdList}
+            isLoading={createdQ.isLoading || createdQ.isFetchingNextPage}
+            isError={!!createdQ.isError}
+            emptyText='등록한 상품이 없어요'
+            mapFn={mapCreated}
+            hasNextPage={!!createdQ.hasNextPage}
+            fetchNextPage={() => createdQ.fetchNextPage()}
+          />
+        )}
+
+        {tab === 'wishlist' && (
+          <SectionBlock
+            list={favoriteList}
+            isLoading={favoriteQ.isLoading || favoriteQ.isFetchingNextPage}
+            isError={!!favoriteQ.isError}
+            emptyText='찜한 상품이 없어요'
+            mapFn={mapFavorite}
+            hasNextPage={!!favoriteQ.hasNextPage}
+            fetchNextPage={() => favoriteQ.fetchNextPage()}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/mypage/components/ProfileTabsSection.tsx
+++ b/src/features/mypage/components/ProfileTabsSection.tsx
@@ -1,17 +1,12 @@
 'use client';
 
-import { useInfiniteQuery } from '@tanstack/react-query';
 import React, { useMemo, useState } from 'react';
 
 import VirtualizedContentGrid from '@/features/mainPage/components/VirtualizedContentGrid';
 import ProfileTabs from '@/features/mypage/components/ProfileTabs';
 import { TEAM_ID } from '@/shared/constants/constants';
 
-import {
-  listUserReviewedProducts,
-  listUserCreatedProducts,
-  listUserFavoriteProducts,
-} from '../../../../openapi/requests/services.gen';
+import { useInfiniteApi } from '../../../../openapi/queries/infiniteQueries';
 
 import type {
   ListUserReviewedProductsDefaultResponse as ReviewedResp,
@@ -21,29 +16,18 @@ import type {
 import type { ContentItem } from '@/shared/types/content';
 
 type TabKey = 'reviews' | 'items' | 'wishlist';
-
 type ReviewedItem = NonNullable<ReviewedResp>['list'][number];
 type CreatedItem = NonNullable<CreatedResp>['list'][number];
 type FavoriteItem = NonNullable<FavoriteResp>['list'][number];
 
 type Props = {
   userId: number;
-  mapReviewed: (item: ReviewedItem) => ContentItem;
-  mapCreated: (item: CreatedItem) => ContentItem;
-  mapFavorite: (item: FavoriteItem) => ContentItem;
+  mapReviewed: (i: ReviewedItem) => ContentItem;
+  mapCreated: (i: CreatedItem) => ContentItem;
+  mapFavorite: (i: FavoriteItem) => ContentItem;
 };
 
-type SectionProps<T> = {
-  list: T[];
-  isLoading: boolean;
-  isError: boolean;
-  emptyText: string;
-  mapFn: (it: T) => ContentItem;
-  hasNextPage: boolean;
-  fetchNextPage: () => void;
-};
-
-const SectionBlock = <T,>({
+function SectionBlock<T>({
   list,
   isLoading,
   isError,
@@ -51,15 +35,21 @@ const SectionBlock = <T,>({
   mapFn,
   hasNextPage,
   fetchNextPage,
-}: SectionProps<T>) => {
+}: {
+  list: T[];
+  isLoading: boolean;
+  isError: boolean;
+  emptyText: string;
+  mapFn: (it: T) => ContentItem;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}) {
   if (isLoading && list.length === 0) return <p className='text-gray-400'>불러오는 중…</p>;
   if (isError) return <p className='text-red-400'>불러오기에 실패했어요.</p>;
   if (list.length === 0) return <p className='text-gray-400'>{emptyText}</p>;
-
-  const items = list.map(mapFn);
   return (
     <VirtualizedContentGrid
-      items={items}
+      items={list.map(mapFn)}
       hasNextPage={hasNextPage}
       fetchNextPage={fetchNextPage}
       isLoading={isLoading}
@@ -67,7 +57,7 @@ const SectionBlock = <T,>({
       rowGap={16}
     />
   );
-};
+}
 
 export default function ProfileTabsSection({
   userId,
@@ -77,108 +67,92 @@ export default function ProfileTabsSection({
 }: Props) {
   const [tab, setTab] = useState<TabKey>('reviews');
 
-  const fetchReviewed = async ({ pageParam }: { pageParam: number | null | undefined }) => {
-    const res = await listUserReviewedProducts({
-      path: { teamId: TEAM_ID as string, userId },
-      query: pageParam ? { cursor: pageParam } : undefined,
-    });
-    return res.data as ReviewedResp;
-  };
+  const reviewedQ = useInfiniteApi<ReviewedItem>(
+    ['user', userId, 'reviews'],
+    '/{teamId}/users/{userId}/reviewed-products',
+    { path: { teamId: TEAM_ID as string, userId } },
+  );
 
-  const fetchCreated = async ({ pageParam }: { pageParam: number | null | undefined }) => {
-    const res = await listUserCreatedProducts({
-      path: { teamId: TEAM_ID as string, userId },
-      query: pageParam ? { cursor: pageParam } : undefined,
-    });
-    return res.data as CreatedResp;
-  };
+  const createdQ = useInfiniteApi<CreatedItem>(
+    ['user', userId, 'items'],
+    '/{teamId}/users/{userId}/created-products',
+    { path: { teamId: TEAM_ID as string, userId } },
+  );
 
-  const fetchFavorite = async ({ pageParam }: { pageParam: number | null | undefined }) => {
-    const res = await listUserFavoriteProducts({
-      path: { teamId: TEAM_ID as string, userId },
-      query: pageParam ? { cursor: pageParam } : undefined,
-    });
-    return res.data as FavoriteResp;
-  };
+  const favoriteQ = useInfiniteApi<FavoriteItem>(
+    ['user', userId, 'wishlist'],
+    '/{teamId}/users/{userId}/favorite-products',
+    { path: { teamId: TEAM_ID as string, userId } },
+  );
 
-  const reviewedQ = useInfiniteQuery({
-    queryKey: ['user', userId, 'reviews'],
-    queryFn: fetchReviewed,
-    initialPageParam: null as number | null,
-    getNextPageParam: (last) => last?.nextCursor ?? undefined,
-    enabled: tab === 'reviews',
-    placeholderData: (prev) => prev,
-    staleTime: 30_000,
-  });
+  const tabMap = useMemo(
+    () =>
+      ({
+        reviews: {
+          list: reviewedQ.data?.items ?? [],
+          isLoading: reviewedQ.isLoading || reviewedQ.isFetchingNextPage,
+          isError: !!reviewedQ.isError,
+          emptyText: '리뷰가 없어요',
+          mapFn: mapReviewed,
+          hasNextPage: !!reviewedQ.hasNextPage,
+          fetchNextPage: () => reviewedQ.fetchNextPage(),
+        },
+        items: {
+          list: createdQ.data?.items ?? [],
+          isLoading: createdQ.isLoading || createdQ.isFetchingNextPage,
+          isError: !!createdQ.isError,
+          emptyText: '등록한 상품이 없어요',
+          mapFn: mapCreated,
+          hasNextPage: !!createdQ.hasNextPage,
+          fetchNextPage: () => createdQ.fetchNextPage(),
+        },
+        wishlist: {
+          list: favoriteQ.data?.items ?? [],
+          isLoading: favoriteQ.isLoading || favoriteQ.isFetchingNextPage,
+          isError: !!favoriteQ.isError,
+          emptyText: '찜한 상품이 없어요',
+          mapFn: mapFavorite,
+          hasNextPage: !!favoriteQ.hasNextPage,
+          fetchNextPage: () => favoriteQ.fetchNextPage(),
+        },
+      }) as const,
+    [
+      reviewedQ.data,
+      reviewedQ.isLoading,
+      reviewedQ.isFetchingNextPage,
+      reviewedQ.isError,
+      reviewedQ.hasNextPage,
+      createdQ.data,
+      createdQ.isLoading,
+      createdQ.isFetchingNextPage,
+      createdQ.isError,
+      createdQ.hasNextPage,
+      favoriteQ.data,
+      favoriteQ.isLoading,
+      favoriteQ.isFetchingNextPage,
+      favoriteQ.isError,
+      favoriteQ.hasNextPage,
+      mapReviewed,
+      mapCreated,
+      mapFavorite,
+    ],
+  );
 
-  const createdQ = useInfiniteQuery({
-    queryKey: ['user', userId, 'items'],
-    queryFn: fetchCreated,
-    initialPageParam: null as number | null,
-    getNextPageParam: (last) => last?.nextCursor ?? undefined,
-    enabled: tab === 'items',
-    placeholderData: (prev) => prev,
-    staleTime: 30_000,
-  });
-
-  const favoriteQ = useInfiniteQuery({
-    queryKey: ['user', userId, 'wishlist'],
-    queryFn: fetchFavorite,
-    initialPageParam: null as number | null,
-    getNextPageParam: (last) => last?.nextCursor ?? undefined,
-    enabled: tab === 'wishlist',
-    placeholderData: (prev) => prev,
-    staleTime: 30_000,
-  });
-
-  const reviewedList: ReviewedItem[] =
-    reviewedQ.data?.pages?.flatMap((p) => (p ? p.list : [])) ?? [];
-
-  const createdList: CreatedItem[] = createdQ.data?.pages?.flatMap((p) => (p ? p.list : [])) ?? [];
-
-  const favoriteList: FavoriteItem[] =
-    favoriteQ.data?.pages?.flatMap((p) => (p ? p.list : [])) ?? [];
+  const active = tabMap[tab];
 
   return (
     <div className='w-full'>
       <ProfileTabs value={tab} onChange={setTab} />
-
       <div className='mt-6 pb-[80px]'>
-        {tab === 'reviews' && (
-          <SectionBlock
-            list={reviewedList}
-            isLoading={reviewedQ.isLoading || reviewedQ.isFetchingNextPage}
-            isError={!!reviewedQ.isError}
-            emptyText='리뷰가 없어요'
-            mapFn={mapReviewed}
-            hasNextPage={!!reviewedQ.hasNextPage}
-            fetchNextPage={() => reviewedQ.fetchNextPage()}
-          />
-        )}
-
-        {tab === 'items' && (
-          <SectionBlock
-            list={createdList}
-            isLoading={createdQ.isLoading || createdQ.isFetchingNextPage}
-            isError={!!createdQ.isError}
-            emptyText='등록한 상품이 없어요'
-            mapFn={mapCreated}
-            hasNextPage={!!createdQ.hasNextPage}
-            fetchNextPage={() => createdQ.fetchNextPage()}
-          />
-        )}
-
-        {tab === 'wishlist' && (
-          <SectionBlock
-            list={favoriteList}
-            isLoading={favoriteQ.isLoading || favoriteQ.isFetchingNextPage}
-            isError={!!favoriteQ.isError}
-            emptyText='찜한 상품이 없어요'
-            mapFn={mapFavorite}
-            hasNextPage={!!favoriteQ.hasNextPage}
-            fetchNextPage={() => favoriteQ.fetchNextPage()}
-          />
-        )}
+        <SectionBlock
+          list={active.list}
+          isLoading={active.isLoading}
+          isError={active.isError}
+          emptyText={active.emptyText}
+          mapFn={active.mapFn}
+          hasNextPage={active.hasNextPage}
+          fetchNextPage={active.fetchNextPage}
+        />
       </div>
     </div>
   );

--- a/src/shared/utils/mapToContentItem.ts
+++ b/src/shared/utils/mapToContentItem.ts
@@ -1,0 +1,57 @@
+import type { ContentItem } from '@/shared/types/content';
+
+type ProductLike = {
+  id: number;
+  name?: string;
+  title?: string;
+  image?: string | null;
+  favoriteCount?: number;
+  reviewCount?: number;
+  averageRating?: number;
+  rating?: number;
+};
+
+const isRecord = (record: unknown): record is Record<string, unknown> =>
+  typeof record === 'object' && record !== null;
+
+const getProp = <T>(obj: unknown, key: string): T | undefined => {
+  if (!isRecord(obj)) return undefined;
+  return obj[key] as T | undefined;
+};
+
+const isProductLike = (record: unknown): record is ProductLike => {
+  if (!isRecord(record)) return false;
+  const id = record['id'];
+  return typeof id === 'number';
+};
+
+const getProductLike = (item: unknown): ProductLike | undefined => {
+  const base = getProp<unknown>(item, 'product') ?? item;
+  return isProductLike(base) ? base : undefined;
+};
+
+export type MapOptions = {
+  preferSelfRating?: boolean;
+  selfRatingKey?: string;
+};
+
+const toSrc = (url?: string | null): string =>
+  url && url.trim() !== '' ? url : '/images/ProfileFallbackImg.png';
+
+export function mapToContentItem(x: unknown, opts?: MapOptions): ContentItem {
+  const p = getProductLike(x);
+  const selfRating = getProp<number>(x, opts?.selfRatingKey ?? 'rating');
+
+  const rating = opts?.preferSelfRating
+    ? Number(selfRating ?? p?.averageRating ?? p?.rating ?? 0)
+    : Number(p?.averageRating ?? p?.rating ?? selfRating ?? 0);
+
+  return {
+    contentId: p?.id ?? 0,
+    title: p?.name ?? p?.title ?? '이름 없는 콘텐츠',
+    contentImage: toSrc(p?.image ?? null),
+    favoriteCount: Number(p?.favoriteCount ?? 0),
+    reviewCount: Number(p?.reviewCount ?? 0),
+    rating,
+  };
+}


### PR DESCRIPTION
[HOY-132] feat: 탭 리스트 api 연결 / 무한스크롤 적용/ 마이페이지 오류 수정

## ✏️ 작업 내용 (📷 스크린샷•동영상)


https://github.com/user-attachments/assets/dd0c4ca1-a94a-47b6-a7a5-ac1834f2208e



## 📌 변경 범위

src/features/mypage/components/ProfileTabsSection.tsx
src/app/user/[userId]/page.tsx
 src/app/mypage/page.tsx

## ✅ 체크리스트

- [ ] pr요청시 lint + 빌드를 통과했습니다.
- [ ] 코드가 스타일 가이드를 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 복잡/핵심 로직에 주석을 추가했습니다.
- [ ] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

급한 마음에 탭 api와 무한스크롤 지피티사용을 거의 했습니더 .... 그래서 저도 코드를 아직 다 이해하지 못했지만 일단 pr을 올려서 보여드려야 할 것 같아서 올렸습니다!!! 내일 리뷰 받으면서 코드 숙지를 하겠습니다 죄송합니다 ㅠㅠ  


[HOY-132]: https://team7advancedproject.atlassian.net/browse/HOY-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ