### PR TITLE
[HOY-176] fix: SafeProfileImage에서 이미지 업데이트가 즉시 반영되지 않던 문제 수정 (윤정환)

### DIFF
--- a/src/shared/components/SafeProfileImage.tsx
+++ b/src/shared/components/SafeProfileImage.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 
-import { ComponentProps, useState } from 'react';
+import { ComponentProps, useEffect, useState } from 'react';
 
 import profileFallbackImage from '../../../public/images/ProfileFallbackImg.png';
 import { cn } from '../lib/cn';
@@ -22,6 +22,11 @@ const SafeProfileImage = ({
   ...props
 }: Props) => {
   const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    setHasError(false);
+  }, [src]);
+
   return (
     <div className={cn(wrapperClassName, className)}>
       <Image


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->
기존에 SafeProfileImage가 유효하지 않은 src를 받으면 onError에서 hasError를 true로 바꾸고 fallback 이미지를 보여주는 방식으로 동작했는데, 중간에 src가 유효한 이미지로 바뀌었을 때 상태를 다시 false로 변경해주는 코드가 없었습니다.
따라서 프로필 업데이트에서 fallback이미지가 설정된 프로필을 유효한 이미지로 바꿔줬을 때 변경사항이 바로 반영되지 않고 새로고침으로 컴포넌트를 unmount시켜줘야 상태가 초기화 되어서 변경사항이 제대로 ui에 반영됐습니다.
이를 해결하기 위해서 src에 변경이 있으면 자동으로 상태를 초기화하는 코드를 추가해 프로필 이미지 변경이 어떤 경우라도 바로 ui에 반영될 수 있도록 변경했습니다.

## 📌 변경 범위

<!-- 영향 받는 서비스, 모듈, UI 등 -->
SafeProfileImage.tsx

## ✅ 체크리스트

- [ ] pr요청시 lint + 빌드를 통과했습니다.
- [ ] 코드가 스타일 가이드를 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 복잡/핵심 로직에 주석을 추가했습니다.
- [ ] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
