### PR TITLE
[HOY-160] fix: 링크 콘텐츠 이름 부분에 따옴표 추가 수정(김인)

### DIFF
--- a/src/features/compare/components/CompareResultSummary.tsx
+++ b/src/features/compare/components/CompareResultSummary.tsx
@@ -49,7 +49,7 @@ function DetailLink({
       title={text}
       className={clsx(PILL_CONTAINER_BASE, PILL_COLOR[side])}
     >
-      <span className={LINK_TEXT_BASE}>{text} 리뷰 보기</span>
+      <span className={LINK_TEXT_BASE}>&quot;{text}&quot; 리뷰 보기</span>
     </Link>
   );
 }


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)
<img width="2560" height="1368" alt="스크린샷 2025-09-14 223622" src="https://github.com/user-attachments/assets/9bd7f239-4fcc-49e7-8543-22a1da6d72c6" />


- **상세 페이지로 가는 링크의 콘텐츠 이름 부분에 따옴표를 추가했습니다.**

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위
src/features/compare/components/CompareResultSummary.tsx: 콘텐츠 이름 부분에 따옴표 추가
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 복잡/핵심 로직에 주석을 추가했습니다.
- [ ] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항
간단한 사항이니 아무나 체크해 주시면 감사하겠습니다!
<!-- 리뷰어와 논의하고 싶은 부분 -->
