### PR TITLE
[HOY-183] fix: 프로필 페이지 수정사항 반영 (배혜민)

### DIFF
--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -105,7 +105,7 @@ export default function UserPage() {
   const handleFollowToggle = () => {
     isFollowing ? fm.unfollow() : fm.follow();
     isFollowing
-      ? toast.success(toastName + '남울 언팔로우 했습니다')
+      ? toast.success(toastName + '님을 언팔로우 했습니다')
       : toast.success(toastName + '님을 팔로우 했습니다');
   };
 

--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -3,12 +3,12 @@
 import { useParams, useRouter } from 'next/navigation';
 
 import React, { useState } from 'react';
+import { toast } from 'react-toastify';
 
 import ActivityCard from '@/features/mypage/components/activityCard';
 import ProfileCard from '@/features/mypage/components/ProfileCard';
 import ProfileTabsSection from '@/features/mypage/components/ProfileTabsSection';
 import { useFollowMutations } from '@/features/user/hooks/useFollowMutaion';
-import BaseModal from '@/shared/components/BaseModal';
 import ProfilePageSkeleton from '@/shared/components/skeleton/PofilePageSkeleton';
 import { TEAM_ID, PATH_OPTION } from '@/shared/constants/constants';
 import { useUserStore } from '@/shared/stores/userStore';
@@ -103,6 +103,7 @@ export default function UserPage() {
 
   const handleFollowToggle = () => {
     isFollowing ? fm.unfollow() : fm.follow();
+    isFollowing ? toast.success('팔로우 취소 성공') : toast.success('팔로우 성공');
   };
 
   return (

--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -100,10 +100,13 @@ export default function UserPage() {
 
   const card = mapUserToCard(userDetail);
   const isFollowing = card.isFollowing;
+  const toastName = card.name;
 
   const handleFollowToggle = () => {
     isFollowing ? fm.unfollow() : fm.follow();
-    isFollowing ? toast.success('팔로우 취소 성공') : toast.success('팔로우 성공');
+    isFollowing
+      ? toast.success(toastName + '남울 언팔로우 했습니다')
+      : toast.success(toastName + '님을 팔로우 했습니다');
   };
 
   return (

--- a/src/features/mypage/components/ProfileCard.tsx
+++ b/src/features/mypage/components/ProfileCard.tsx
@@ -182,7 +182,7 @@ const FOLLOW_INFO_WRAPPER = 'mt-[30px] flex justify-between text-center';
 const FOLLOW_BOX_LEFT = ' border-r border-r-black-700';
 const FOLLOW_BOX = 'group w-[50%] inline-flex flex-col items-center text-center ';
 const FOLLOW_COUNT = 'text-base-semibold  text-white group-hover:!text-main transition-colors ';
-const FOLLOW_LABEL = 'text-md-regular  text-gray-400 group-hover:!text-main transition-colors';
+const FOLLOW_LABEL = 'text-md-regular  text-gray-400 ';
 
 const BUTTON_GROUP = 'mt-[30px] flex flex-col gap-[10px]';
 const BUTTON_BASE = 'text-base-semibold w-full rounded-[8px] py-[15px] transition cursor-pointer';

--- a/src/features/mypage/components/ProfileCard.tsx
+++ b/src/features/mypage/components/ProfileCard.tsx
@@ -88,7 +88,7 @@ export default function ProfileCard({
 
       <div className={FOLLOW_INFO_WRAPPER}>
         <div
-          className={FOLLOW_BOX_LEFT}
+          className={clsx(FOLLOW_BOX, FOLLOW_BOX_LEFT)}
           role='button'
           tabIndex={0}
           data-type='followers'
@@ -106,7 +106,7 @@ export default function ProfileCard({
           </span>
         </div>
         <div
-          className={'inline-flex w-[50%] flex-col items-center text-center'}
+          className={FOLLOW_BOX}
           role='button'
           tabIndex={0}
           data-type='following'
@@ -115,11 +115,11 @@ export default function ProfileCard({
           aria-label='팔로잉 보기'
         >
           <strong
-            className={clsx(FOLLOW_COUNT, hasFollowers ? 'cursor-pointer' : 'cursor-default')}
+            className={clsx(FOLLOW_COUNT, hasFollowing ? 'cursor-pointer' : 'cursor-default')}
           >
             {following}
           </strong>
-          <span className={clsx(FOLLOW_LABEL, hasFollowers ? 'cursor-pointer' : 'cursor-default')}>
+          <span className={clsx(FOLLOW_LABEL, hasFollowing ? 'cursor-pointer' : 'cursor-default')}>
             팔로잉
           </span>
         </div>
@@ -179,10 +179,10 @@ const CARD_CONTAINER =
 const PROFILE_TEXT_WRAPPER = 'mt-[30px] flex flex-col items-center gap-[10px] text-center';
 
 const FOLLOW_INFO_WRAPPER = 'mt-[30px] flex justify-between text-center';
-const FOLLOW_BOX_LEFT =
-  'w-[50%] border-r border-r-black-700 inline-flex flex-col items-center text-center ';
-const FOLLOW_COUNT = 'text-base-semibold  text-white hover:text-main';
-const FOLLOW_LABEL = 'text-md-regular  text-gray-400';
+const FOLLOW_BOX_LEFT = ' border-r border-r-black-700';
+const FOLLOW_BOX = 'group w-[50%] inline-flex flex-col items-center text-center ';
+const FOLLOW_COUNT = 'text-base-semibold  text-white group-hover:!text-main transition-colors ';
+const FOLLOW_LABEL = 'text-md-regular  text-gray-400 group-hover:!text-main transition-colors';
 
 const BUTTON_GROUP = 'mt-[30px] flex flex-col gap-[10px]';
 const BUTTON_BASE = 'text-base-semibold w-full rounded-[8px] py-[15px] transition cursor-pointer';

--- a/src/features/mypage/components/ProfileCard.tsx
+++ b/src/features/mypage/components/ProfileCard.tsx
@@ -44,6 +44,8 @@ export default function ProfileCard({
 }: ProfileCardProps) {
   const [isFollowModalOpen, setIsFollowModalOpen] = useState(false);
   const [followModalType, setFollowModalType] = useState<'followers' | 'following' | null>(null);
+  const hasFollowers = followers > 0;
+  const hasFollowing = following > 0;
 
   const [isRedirectOpen, setIsRedirectOpen] = useState(false);
   const openModal = (type: 'followers' | 'following') => {
@@ -94,11 +96,17 @@ export default function ProfileCard({
           onKeyDown={onKeyOpen}
           aria-label='팔로워 보기'
         >
-          <strong className={FOLLOW_COUNT}>{followers}</strong>
-          <span className={FOLLOW_LABEL}>팔로워</span>
+          <strong
+            className={clsx(FOLLOW_COUNT, hasFollowers ? 'cursor-pointer' : 'cursor-default')}
+          >
+            {followers}
+          </strong>
+          <span className={clsx(FOLLOW_LABEL, hasFollowers ? 'cursor-pointer' : 'cursor-default')}>
+            팔로워
+          </span>
         </div>
         <div
-          className='w-[50%]'
+          className={'inline-flex w-[50%] flex-col items-center text-center'}
           role='button'
           tabIndex={0}
           data-type='following'
@@ -106,8 +114,14 @@ export default function ProfileCard({
           onKeyDown={onKeyOpen}
           aria-label='팔로잉 보기'
         >
-          <strong className={FOLLOW_COUNT}>{following}</strong>
-          <span className={FOLLOW_LABEL}>팔로잉</span>
+          <strong
+            className={clsx(FOLLOW_COUNT, hasFollowers ? 'cursor-pointer' : 'cursor-default')}
+          >
+            {following}
+          </strong>
+          <span className={clsx(FOLLOW_LABEL, hasFollowers ? 'cursor-pointer' : 'cursor-default')}>
+            팔로잉
+          </span>
         </div>
       </div>
 
@@ -165,9 +179,10 @@ const CARD_CONTAINER =
 const PROFILE_TEXT_WRAPPER = 'mt-[30px] flex flex-col items-center gap-[10px] text-center';
 
 const FOLLOW_INFO_WRAPPER = 'mt-[30px] flex justify-between text-center';
-const FOLLOW_BOX_LEFT = 'w-[50%] border-r border-r-black-700 cursor-pointer';
-const FOLLOW_COUNT = 'text-base-semibold block text-white cursor-pointer';
-const FOLLOW_LABEL = 'text-md-regular block text-gray-400 cursor-pointer';
+const FOLLOW_BOX_LEFT =
+  'w-[50%] border-r border-r-black-700 inline-flex flex-col items-center text-center ';
+const FOLLOW_COUNT = 'text-base-semibold  text-white hover:text-main';
+const FOLLOW_LABEL = 'text-md-regular  text-gray-400';
 
 const BUTTON_GROUP = 'mt-[30px] flex flex-col gap-[10px]';
 const BUTTON_BASE = 'text-base-semibold w-full rounded-[8px] py-[15px] transition cursor-pointer';

--- a/src/shared/components/card/avatarCard.tsx
+++ b/src/shared/components/card/avatarCard.tsx
@@ -81,7 +81,7 @@ export default function ProfileBadge({
   };
 
   return (
-    <div className={clsx('flex min-w-0', variant === 'follower' && 'mb-[40px]')}>
+    <div className={clsx('flex min-w-0', variant === 'follower' && 'mb-[15px] xl:mb-[20px]')}>
       {/* 아바타 */}
       <div
         className={clsx(


### PR DESCRIPTION
[HOY-183] fix: 프로필 페이지 수정사항 반영 (배혜민)


## ✏️ 작업 내용 (📷 스크린샷•동영상)

https://github.com/user-attachments/assets/12b3e34a-982a-4fcc-ab62-c0c38ee4f0f7



- 프로필 카드에 팔로우/팔로워 없을 때 cursor pointer 제거 
- 프로필 카드 팔로우/팔로워 감싸는 div 말고 텍스트만 cursor pointer 
- 팔로우/팔로워 모달 리스트 간격 피그마와 같이 조정 
- 팔로우/팔로워 글자 hover 색상 바뀌게
-  팔로우하기/편집하기/로그아웃 버튼 망가지는거 다시 확인 
- 팔로우/언팔로우 했을 때 토스트 

## 📌 변경 범위
src/features/mypage/components/ProfileCard.tsx
src/shared/components/card/avatarCard.tsx
src/app/mypage/page.tsx
src/app/user/[userId]/page.tsx

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [ ] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항


[HOY-183]: https://team7advancedproject.atlassian.net/browse/HOY-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ