### PR TITLE
feat(profilePage):  프로필 탭 섹션 빈/에러 상태 ContentEmpty 적용 (이유진)

### DIFF
--- a/src/features/mainPage/components/ContentEmpty.tsx
+++ b/src/features/mainPage/components/ContentEmpty.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import { Search, AlertTriangle } from 'lucide-react';
+import { Inbox, AlertTriangle } from 'lucide-react';
 
 type ContentEmptyProps = {
   /** 상태: 기본값 'empty' */
   variant?: 'empty' | 'error';
   /** 제목 문구 */
   title?: string;
-  /** 설명 문구 */
+  /** 설명 문구 (undefined면 아예 숨김) */
   description?: string;
 };
 
 const ContentEmpty = ({ variant = 'empty', title, description }: ContentEmptyProps) => {
   const isError = variant === 'error';
+
+  const defaultTitle = isError
+    ? '콘텐츠를 불러오는 중 문제가 발생했어요'
+    : '아직 등록된 콘텐츠가 없어요';
 
   return (
     <div className='flex flex-col items-center justify-center py-20 text-center'>
@@ -23,20 +27,13 @@ const ContentEmpty = ({ variant = 'empty', title, description }: ContentEmptyPro
           strokeWidth={1.5}
         />
       ) : (
-        <Search aria-hidden='true' className='mb-6 h-16 w-16 text-gray-500' strokeWidth={1.5} />
+        <Inbox aria-hidden='true' className='mb-6 h-16 w-16 text-gray-500' strokeWidth={1.5} />
       )}
 
-      <h2 className='text-lg-semibold mb-2 text-white'>
-        {title ??
-          (isError ? '콘텐츠를 불러오는 중 문제가 발생했어요' : '아직 등록된 콘텐츠가 없어요')}
-      </h2>
+      <h2 className='text-lg-semibold mb-2 text-white'>{title ?? defaultTitle}</h2>
 
-      <p className='text-gray-400'>
-        {description ??
-          (isError
-            ? '잠시 후 다시 시도해주세요'
-            : '화면 하단의 플로팅 버튼을 눌러 콘텐츠를 추가해보세요')}
-      </p>
+      {/* description이 undefined가 아닐 때만 출력 */}
+      {description !== undefined && <p className='text-gray-400'>{description}</p>}
     </div>
   );
 };

--- a/src/features/mypage/components/ProfileTabsSection.tsx
+++ b/src/features/mypage/components/ProfileTabsSection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 
+import ContentEmpty from '@/features/mainPage/components/ContentEmpty';
 import VirtualizedContentGrid from '@/features/mainPage/components/VirtualizedContentGrid';
 import ProfileTabs from '@/features/mypage/components/ProfileTabs';
 import { PATH_OPTION } from '@/shared/constants/constants';
@@ -42,6 +43,7 @@ function SectionBlock<T>({
   isLoading,
   isError,
   emptyText,
+  errorText,
   mapFn,
   hasNextPage,
   fetchNextPage,
@@ -50,13 +52,19 @@ function SectionBlock<T>({
   isLoading: boolean;
   isError: boolean;
   emptyText: string;
+  errorText: string;
   mapFn: (it: T) => ContentItem;
   hasNextPage: boolean;
   fetchNextPage: () => void;
 }) {
-  if (isLoading && list.length === 0) return <p className='text-gray-400'>불러오는 중…</p>;
-  if (isError) return <p className='text-red-400'>불러오기에 실패했어요.</p>;
-  if (list.length === 0) return <p className='text-gray-400'>{emptyText}</p>;
+  if (isError) {
+    return (
+      <ContentEmpty variant='error' title={errorText} description='잠시 후 다시 시도해주세요' />
+    );
+  }
+  if (list.length === 0) {
+    return <ContentEmpty title={emptyText} />;
+  }
   return (
     <VirtualizedContentGrid
       items={list.map(mapFn)}
@@ -102,7 +110,8 @@ export default function ProfileTabsSection({
           list: reviewedQ.data?.items ?? [],
           isLoading: reviewedQ.isLoading || reviewedQ.isFetchingNextPage,
           isError: !!reviewedQ.isError,
-          emptyText: '리뷰가 없어요',
+          emptyText: '아직 등록한 리뷰가 없어요',
+          errorText: '리뷰 목록을 불러오지 못했어요',
           mapFn: mapReviewed,
           hasNextPage: !!reviewedQ.hasNextPage,
           fetchNextPage: () => reviewedQ.fetchNextPage(),
@@ -111,7 +120,8 @@ export default function ProfileTabsSection({
           list: createdQ.data?.items ?? [],
           isLoading: createdQ.isLoading || createdQ.isFetchingNextPage,
           isError: !!createdQ.isError,
-          emptyText: '등록한 콘텐츠가 없어요',
+          emptyText: '아직 등록한 콘텐츠가 없어요',
+          errorText: '등록한 콘텐츠를 불러오지 못했어요',
           mapFn: mapCreated,
           hasNextPage: !!createdQ.hasNextPage,
           fetchNextPage: () => createdQ.fetchNextPage(),
@@ -120,7 +130,8 @@ export default function ProfileTabsSection({
           list: favoriteQ.data?.items ?? [],
           isLoading: favoriteQ.isLoading || favoriteQ.isFetchingNextPage,
           isError: !!favoriteQ.isError,
-          emptyText: '찜한 콘텐츠가 없어요',
+          emptyText: '아직 찜한 콘텐츠가 없어요',
+          errorText: '찜한 콘텐츠를 불러오지 못했어요',
           mapFn: mapFavorite,
           hasNextPage: !!favoriteQ.hasNextPage,
           fetchNextPage: () => favoriteQ.fetchNextPage(),
@@ -140,6 +151,7 @@ export default function ProfileTabsSection({
           isLoading={active.isLoading}
           isError={active.isError}
           emptyText={active.emptyText}
+          errorText={active.errorText}
           mapFn={active.mapFn}
           hasNextPage={active.hasNextPage}
           fetchNextPage={active.fetchNextPage}


### PR DESCRIPTION
## ✏️ 작업 내용 (📷 스크린샷•동영상)

* `ProfileTabsSection`

  * 탭별 빈 상태 / 에러 상태를 **ContentEmpty 컴포넌트**로 통일
  * 탭별로 `emptyText`, `errorText` 메시지를 분리하여 전달

* `ContentEmpty`

  * 빈 상태 아이콘을 `Inbox` 아이콘으로 교체 (기존 `Search` 제거)
  * `description` prop이 `undefined`일 경우 `<p>` 자체가 출력되지 않도록 처리
  * 기본 문구:

    * variant=`error` → "콘텐츠를 불러오는 중 문제가 발생했어요"
    * variant=`empty` → "아직 등록된 콘텐츠가 없어요"
<img width="1125" height="730" alt="image" src="https://github.com/user-attachments/assets/3d58f0bc-1232-4c9f-a7eb-90ed0a643ff7" />
<img width="1127" height="701" alt="image" src="https://github.com/user-attachments/assets/a4ba76ec-d7e1-46df-aef0-616d8c4a40de" />

---

## 📌 변경 범위

* 마이페이지 > 프로필 탭 섹션 (`ProfileTabsSection`)
* 공용 빈 상태 UI 컴포넌트 (`ContentEmpty`)

---

## ✅ 체크리스트

* [x] pr요청시 lint + 빌드를 통과했습니다.
* [x] 코드가 스타일 가이드를 따릅니다.
* [x] 자체 코드 리뷰를 완료했습니다.
* [ ] 복잡/핵심 로직에 주석을 추가했습니다.
* [ ] 관심사 분리를 확인했습니다.

---

## 🗨️ 논의 사항

