### PR TITLE
[HOY-188] feat: 모바일 바텀시트 로그인, 회원가입 버튼에 리다이렉트 로직 적용 (윤정환)

### DIFF
--- a/src/shared/components/MobileGnbSheet.tsx
+++ b/src/shared/components/MobileGnbSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 import clsx from 'clsx';
 import { MenuIcon } from 'lucide-react';
@@ -27,6 +28,11 @@ const LINK_STYLE =
  * - 비교할 컨텐츠가 두 개 준비되면 비교하기 버튼과 햄버거 버튼 ui 변화
  */
 const MobileGnbSheet = ({ isLoggedIn, isCompareReady }: GnbSheetProps) => {
+  const currentPath = usePathname();
+  const params = useSearchParams();
+  const redirectUrl = params.get('redirect_url') ? params.get('redirect_url') : currentPath;
+  const query = `?redirect_url=${redirectUrl}`;
+
   // 로그인 여부에 따라 메뉴 항목을 분기
   const items = isLoggedIn
     ? [
@@ -34,8 +40,8 @@ const MobileGnbSheet = ({ isLoggedIn, isCompareReady }: GnbSheetProps) => {
         { href: '/mypage', label: '마이페이지' },
       ]
     : [
-        { href: '/signin', label: '로그인' },
-        { href: '/signup', label: '회원가입' },
+        { href: `/signin${query}`, label: '로그인' },
+        { href: `/signup${query}`, label: '회원가입' },
       ];
 
   return (


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->
GNB의 pc, 태블릿 뷰에서의 로그인, 회원가입 버튼과 모바일 뷰 바텀시트의 로그인, 회원가입이 다른 버튼임을 몰라 적용하지 못했던 리다이렉트 로직을, 바텀시트 버튼에도 추가했습니다.

https://github.com/user-attachments/assets/ea6b97a9-13e6-430d-b8b7-07ab921f805c



## 📌 변경 범위

<!-- 영향 받는 서비스, 모듈, UI 등 -->
MobileGnbSheet.tsx

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [ ] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
