### PR TITLE
[Hoy 192] 스켈레톤 무한 로딩 & 깜빡임 문제 해결 

### DIFF
--- a/src/shared/components/SafeProfileImage.tsx
+++ b/src/shared/components/SafeProfileImage.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 
-import { ComponentProps, useEffect, useState } from 'react';
+import React, { ComponentProps, useEffect, useState } from 'react';
 
 import profileFallbackImage from '../../../public/images/ProfileFallbackImg.png';
 import { cn } from '../lib/cn';
@@ -65,4 +65,4 @@ const SafeProfileImage = ({
   );
 };
 
-export default SafeProfileImage;
+export default React.memo(SafeProfileImage);

--- a/src/shared/lib/wsrvLoader.ts
+++ b/src/shared/lib/wsrvLoader.ts
@@ -11,5 +11,11 @@ type LoaderProps = {
  */
 export default function wsrvLoader({ src, width, quality }: LoaderProps): string {
   const q = quality || 75;
+
+  // 로컬 public 폴더 이미지 → wsrv.nl 안 거치고 그대로 사용
+  if (src.startsWith('/')) {
+    return src;
+  }
+
   return `https://wsrv.nl/?url=${encodeURIComponent(src)}&w=${width}&q=${q}&output=webp`;
 }


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)
### Before 
<img width="258" height="159" alt="image" src="https://github.com/user-attachments/assets/9bd1f3e8-0667-4d55-8e5a-56c6e4aa8b2b" />

### After
<img width="238" height="137" alt="image" src="https://github.com/user-attachments/assets/48834330-ad2c-42c7-9d82-f89e312e4c0c" />

**1. 스켈레톤 무한 로딩 문제**

- 원인: 외부 이미지 로더 wsrv.nl 적용 후 fallback 이미지를 포함한 외부 이미지 로딩 시 `onLoadingComplete` 이벤트가 지연되면서 스켈레톤이 계속 남아있음
- 해결: fallback 이미지가 있을 때 `loaded` 상태를 초기값 `true`로 세팅하여 스켈레톤이 불필요하게 남지 않도록 처리.

**2. 이미지 깜빡임 문제**

- 원인: React가 fallback 포함 이미지를 계속 재렌더링 → transition이 반복 적용되며 깜빡임 발생
- 해결: `React.memo(SafeProfileImage)` 적용으로 props가 변하지 않으면 재렌더링을 방지하여 깜빡임 제거

**참고**
- wsrv.nl 적용 전에는 Vercel 환경 특성상 이미지 로딩이 빨라 기존 `SafeProfileImage`취약점이 드러나지 않았습니다.
  wsrv.nl 적용 후 외부 URL 처리 지연과 가상화 스크롤 환경에서 로딩 상태 취약점이 드러나 무한 스켈레톤과 깜빡임이 발생했습니다.

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위

<!-- 영향 받는 서비스, 모듈, UI 등 -->

- `src/shared/components/SafeProfileImage.tsx`
- `src/shared/lib/wsrvLoader.ts`
## ✅ 체크리스트

- [ ] pr요청시 lint + 빌드를 통과했습니다.
- [ ] 코드가 스타일 가이드를 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 복잡/핵심 로직에 주석을 추가했습니다.
- [ ] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
