### PR TITLE
[HOY-194] refactor: 접근성 개선 및 리뷰 피드백 반영 (이유진)

### DIFF
--- a/src/features/mainPage/components/AddContentModal.tsx
+++ b/src/features/mainPage/components/AddContentModal.tsx
@@ -29,6 +29,7 @@ import {
 /* ───────── 상수 / 타입 ───────── */
 
 type CategoryOption = { name: string; value: number };
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
 /** Dropdown mixed value → number 로 변환 */
 const toNumber = (value: unknown): number => {
@@ -125,6 +126,11 @@ const AddContentModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => 
       return;
     }
 
+    // 파일 크기 검증
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error('파일 크기는 5MB 이하여야 합니다.');
+      return;
+    }
     setValue('images', [file], {
       shouldDirty: true,
       shouldTouch: true,

--- a/src/features/mainPage/components/ArrowList.tsx
+++ b/src/features/mainPage/components/ArrowList.tsx
@@ -83,7 +83,7 @@ const ArrowList = ({ children }: ArrowListProps) => {
   });
 
   return (
-    <ul role='list' tabIndex={-1} onKeyDown={handleKeyDown} className='outline-none'>
+    <ul tabIndex={-1} onKeyDown={handleKeyDown} className='outline-none'>
       {enhancedChildren}
     </ul>
   );

--- a/src/features/mainPage/components/ArrowList.tsx
+++ b/src/features/mainPage/components/ArrowList.tsx
@@ -30,7 +30,7 @@ const ArrowList = ({ children }: ArrowListProps) => {
     itemRefs.current = itemRefs.current.slice(0, childrenArray.length);
   }, [childrenArray.length]);
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
     const { key } = e;
     if (key !== 'ArrowDown' && key !== 'ArrowUp') return;
 
@@ -83,9 +83,9 @@ const ArrowList = ({ children }: ArrowListProps) => {
   });
 
   return (
-    <div role='listbox' tabIndex={-1} onKeyDown={handleKeyDown} className='outline-none'>
+    <ul role='list' tabIndex={-1} onKeyDown={handleKeyDown} className='outline-none'>
       {enhancedChildren}
-    </div>
+    </ul>
   );
 };
 

--- a/src/features/mainPage/components/CategoryItem.tsx
+++ b/src/features/mainPage/components/CategoryItem.tsx
@@ -49,6 +49,7 @@ const CategoryItem = ({
 }: CategoryItemProps) => (
   <Link
     href={href}
+    aria-label={category.name}
     replace
     className={`${BASE_STYLE} ${
       isSelected ? VARIANT_STYLE.selected : VARIANT_STYLE.default

--- a/src/features/mainPage/components/CategorySidebar.tsx
+++ b/src/features/mainPage/components/CategorySidebar.tsx
@@ -31,13 +31,9 @@ const CategorySidebar = () => {
               active ? null : Number(category.id),
             );
             return (
-              <CategoryItem
-                key={category.id}
-                category={category}
-                isSelected={active}
-                href={href}
-                className='mb-2 last:mb-0'
-              />
+              <li key={category.id} className='mb-2 last:mb-0'>
+                <CategoryItem category={category} isSelected={active} href={href} />
+              </li>
             );
           })}
         </ArrowList>

--- a/src/features/mainPage/components/ReviewerRanking.tsx
+++ b/src/features/mainPage/components/ReviewerRanking.tsx
@@ -23,6 +23,60 @@ type ReviewerRankingListProps = {
   direction?: Direction; // 기본값: 'row'
 };
 
+type ReviewerRankingSubListProps = {
+  reviewers: Reviewer[];
+  getHref: (userId: number) => string;
+  rankingMap: Map<number, number>;
+};
+
+const ReviewerRankingRowList = ({
+  reviewers,
+  getHref,
+  rankingMap,
+}: ReviewerRankingSubListProps) => (
+  <ul className='flex w-full flex-nowrap gap-5 overflow-x-auto scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
+    {reviewers.map((r) => (
+      <li key={r.userId} className='min-w-[147px] shrink-0 list-none'>
+        <Link href={getHref(r.userId)} draggable={false}>
+          <ProfileBadge
+            variant='ranking'
+            id={r.userId}
+            name={r.name}
+            avatarSrc={r.profileImageUrl}
+            followers={r.followers ?? 0}
+            review={r.review ?? 0}
+            rankingMap={rankingMap}
+          />
+        </Link>
+      </li>
+    ))}
+  </ul>
+);
+
+const ReviewerRankingColList = ({
+  reviewers,
+  getHref,
+  rankingMap,
+}: ReviewerRankingSubListProps) => (
+  <ul className='space-y-[30px]'>
+    {reviewers.map((r) => (
+      <li key={r.userId} className='list-none'>
+        <Link href={getHref(r.userId)} draggable={false}>
+          <ProfileBadge
+            variant='ranking'
+            id={r.userId}
+            name={r.name}
+            avatarSrc={r.profileImageUrl}
+            followers={r.followers ?? 0}
+            review={r.review ?? 0}
+            rankingMap={rankingMap}
+          />
+        </Link>
+      </li>
+    ))}
+  </ul>
+);
+
 /**
  * ReviewerRankingList
  * - reviewers 정렬 후 상위 5명만 표시
@@ -36,47 +90,10 @@ const ReviewerRankingList = ({ reviewers, direction = 'row' }: ReviewerRankingLi
   const rankingMap = useMemo(() => new Map(top.map((r, i) => [r.userId, i + 1])), [top]);
   const getHref = (userId: number) => (meId && userId === meId ? '/mypage' : `/user/${userId}`);
 
-  if (direction === 'row') {
-    return (
-      <ul className='flex w-full flex-nowrap gap-5 overflow-x-auto scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
-        {top.map((r) => (
-          <li key={r.userId} className='min-w-[147px] shrink-0 list-none'>
-            <Link href={getHref(r.userId)} draggable={false}>
-              <ProfileBadge
-                variant='ranking'
-                id={r.userId}
-                name={r.name}
-                avatarSrc={r.profileImageUrl}
-                followers={r.followers ?? 0}
-                review={r.review ?? 0}
-                rankingMap={rankingMap}
-              />
-            </Link>
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  // 세로 모드(col)
-  return (
-    <ul className='space-y-[30px]'>
-      {top.map((r) => (
-        <li key={r.userId} className='list-none'>
-          <Link href={getHref(r.userId)} draggable={false}>
-            <ProfileBadge
-              variant='ranking'
-              id={r.userId}
-              name={r.name}
-              avatarSrc={r.profileImageUrl}
-              followers={r.followers ?? 0}
-              review={r.review ?? 0}
-              rankingMap={rankingMap}
-            />
-          </Link>
-        </li>
-      ))}
-    </ul>
+  return direction === 'row' ? (
+    <ReviewerRankingRowList reviewers={top} getHref={getHref} rankingMap={rankingMap} />
+  ) : (
+    <ReviewerRankingColList reviewers={top} getHref={getHref} rankingMap={rankingMap} />
   );
 };
 

--- a/src/features/mainPage/components/ReviewerRanking.tsx
+++ b/src/features/mainPage/components/ReviewerRanking.tsx
@@ -38,18 +38,32 @@ const ReviewerRankingList = ({ reviewers, direction = 'row' }: ReviewerRankingLi
 
   if (direction === 'row') {
     return (
-      <div
-        role='list'
-        className='flex w-full flex-nowrap gap-5 overflow-x-auto scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
-      >
+      <ul className='flex w-full flex-nowrap gap-5 overflow-x-auto scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
         {top.map((r) => (
-          <Link
-            key={r.userId}
-            href={getHref(r.userId)}
-            role='listitem'
-            className='min-w-[147px] flex-none shrink-0'
-            draggable={false}
-          >
+          <li key={r.userId} className='min-w-[147px] shrink-0 list-none'>
+            <Link href={getHref(r.userId)} draggable={false}>
+              <ProfileBadge
+                variant='ranking'
+                id={r.userId}
+                name={r.name}
+                avatarSrc={r.profileImageUrl}
+                followers={r.followers ?? 0}
+                review={r.review ?? 0}
+                rankingMap={rankingMap}
+              />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  // 세로 모드(col)
+  return (
+    <ul className='space-y-[30px]'>
+      {top.map((r) => (
+        <li key={r.userId} className='list-none'>
+          <Link href={getHref(r.userId)} draggable={false}>
             <ProfileBadge
               variant='ranking'
               id={r.userId}
@@ -60,34 +74,9 @@ const ReviewerRankingList = ({ reviewers, direction = 'row' }: ReviewerRankingLi
               rankingMap={rankingMap}
             />
           </Link>
-        ))}
-      </div>
-    );
-  }
-
-  // 세로 모드(col)
-  return (
-    <div role='list' className='space-y-[30px]'>
-      {top.map((r) => (
-        <Link
-          key={r.userId}
-          href={getHref(r.userId)}
-          role='listitem'
-          className='block'
-          draggable={false}
-        >
-          <ProfileBadge
-            variant='ranking'
-            id={r.userId}
-            name={r.name}
-            avatarSrc={r.profileImageUrl}
-            followers={r.followers ?? 0}
-            review={r.review ?? 0}
-            rankingMap={rankingMap}
-          />
-        </Link>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 };
 


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

[HOY-194] refactor: 접근성 개선 및 리뷰 피드백 반영 (이유진)

## ✏️ 작업 내용 (📷 스크린샷•동영상)

- **접근성 개선**
  - `ArrowList`를 `<div role="listbox">` → `<ul>` 구조로 변경
  - `CategorySidebar`, `ReviewerRankingList`에 `<ul><li><a>` 시멘틱 구조 적용
  - 불필요한 `role` 제거 → 기본 시멘틱 태그 활용
- **리뷰어 랭킹 컴포넌트 리팩토링**
  - `ReviewerRankingList`의 row/col 분기를 전용 컴포넌트(`RowList`, `ColList`)로 분리
  - 가독성 및 유지보수성 향상
- **AddContentModal**
  - 파일 크기 제한 버그 수정 (`5` → `5MB`)
- **useProductNameSearch**
  - queryKey에서 `limit` 제거 → 동일 키워드 캐시 중복 방지
  - 서버 요청은 keyword만 전달, `slice(0, limit)`는 클라이언트에서 처리
  
<img width="1508" height="1137" alt="스크린샷 2025-09-26 095121" src="https://github.com/user-attachments/assets/60db8a38-c37e-4ddb-a90f-76c167b1f1ca" />
<img width="1460" height="670" alt="스크린샷 2025-09-26 105255" src="https://github.com/user-attachments/assets/a27e738e-c2dd-4edc-8ab0-d99e2a42c463" />


## 📌 변경 범위

- `CategorySidebar`, `ArrowList`, `CategoryItem`
- `ReviewerRanking` 컴포넌트 계열
- `AddContentModal`
- `useProductNameSearch` 훅

## ✅ 체크리스트

- [x] PR 요청 시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

