### PR TITLE
[HOY-198]feature: 콘텐츠 카테고리 정보 추가ui 제공(김인)

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -3,6 +3,8 @@
 
 import { toast } from 'react-toastify';
 
+import CompareCategoryNoticeChip from '@/features/compare/components/CompareCategoryNoticeChip';
+import { CATEGORIES } from '@/shared/constants/constants';
 import { useCompareStore } from '@/shared/stores/useCompareStore';
 import { selectA, selectB, selectInFlight } from '@/shared/stores/useCompareStoreSelectors';
 
@@ -12,8 +14,9 @@ import CompareSelect from '../../features/compare/components/CompareSelect';
 
 // 스타일 상수화
 const COMPARE_BASE_STYLE =
-  'grid grid-cols-1 items-end gap-y-[30px] md:gap-[24px] md:h-[55px] md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] xl:h-[70px]';
+  'grid gap-y-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] md:grid-rows-[auto_auto] md:gap-x-4 md:gap-y-2';
 const COMPARE_SELECT_BASE_STYLE = 'w-full max-w-none min-w-0 md:max-w-[360px] xl:max-w-[400px]';
+const COMPARE_BUTTON_STYLE = 'md:row-start-1 md:col-start-3 md:self-end md:justify-self-end';
 const PLACEHOLDER_TEXT = '콘텐츠명을 입력해 주세요';
 
 // 사유별 토스트 유틸
@@ -44,41 +47,60 @@ const ComparePage = () => {
 
   return (
     <main className='mx-auto max-w-4xl p-[24px]'>
-      {/* 비교 입력창 + 버튼 래퍼 - 모바일에선 세로, md 이상에선 가로 */}
       <div className={COMPARE_BASE_STYLE}>
-        {/* 콘텐츠 1 비교 입력창 */}
-        <CompareSelect
-          label='콘텐츠 1'
-          className={COMPARE_SELECT_BASE_STYLE}
-          value={a}
-          scheme='a'
-          onChange={() => {}} // fallback용. 실제 업데이트는 onTryChange가 담당
-          onTryChange={trySetA} // 핵심: 중복 체크 + 상태 반영
-          onError={toastByReason}
-          placeholder={PLACEHOLDER_TEXT}
-        />
+        <div className='md:col-start-1 md:row-start-1'>
+          <CompareSelect
+            label='콘텐츠 1'
+            className={COMPARE_SELECT_BASE_STYLE}
+            value={a}
+            scheme='a'
+            onChange={() => {}}
+            onTryChange={trySetA}
+            onError={toastByReason}
+            placeholder={PLACEHOLDER_TEXT}
+          />
+        </div>
 
-        {/* 콘텐츠 2 비교 입력창 */}
-        <CompareSelect
-          label='콘텐츠 2'
-          className={COMPARE_SELECT_BASE_STYLE}
-          value={b}
-          scheme='b'
-          onChange={() => {}}
-          onTryChange={trySetB}
-          onError={toastByReason}
-          placeholder={PLACEHOLDER_TEXT}
-        />
+        <div className='md:col-start-1 md:row-start-2'>
+          <CompareCategoryNoticeChip
+            side='A'
+            categories={CATEGORIES}
+            hideWhenRequested
+            className='min-h-[22px]'
+          />
+        </div>
 
-        {/* 비교 버튼: 모바일에선 3번째 아이템으로 아래, md 이상에선 3번째 컬럼 오른쪽 정렬 */}
+        <div className='md:col-start-2 md:row-start-1'>
+          <CompareSelect
+            label='콘텐츠 2'
+            className={COMPARE_SELECT_BASE_STYLE}
+            value={b}
+            scheme='b'
+            onChange={() => {}}
+            onTryChange={trySetB}
+            onError={toastByReason}
+            placeholder={PLACEHOLDER_TEXT}
+          />
+        </div>
+
+        <div className='md:col-start-2 md:row-start-2'>
+          <CompareCategoryNoticeChip
+            side='B'
+            categories={CATEGORIES}
+            hideWhenRequested
+            className='min-h-[22px]'
+          />
+        </div>
+
         <CompareButton
-          className='justify-self-start md:justify-self-end'
+          className={COMPARE_BUTTON_STYLE}
           disabled={inFlight}
           onResult={(ok, reason) => {
             if (!ok && reason) toast.info(reason);
           }}
         />
       </div>
+
       {/* 결과 섹션(상태 전환 확인용) */}
       <div className='mt-[100px] md:mt-[140px]'>
         <CompareResult />

--- a/src/features/compare/components/CompareCategoryNoticeChip.tsx
+++ b/src/features/compare/components/CompareCategoryNoticeChip.tsx
@@ -1,0 +1,90 @@
+// 선택한 콘텐츠 카테고리 정보 제공 컴포넌트
+'use client';
+
+import { memo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+
+import Skeleton from '@/shared/components/skeleton/Skeleton';
+import { useCompareStore } from '@/shared/stores/useCompareStore';
+import {
+  selectAForCategory,
+  selectBForCategory,
+  selectInFlight,
+  selectRequested,
+} from '@/shared/stores/useCompareStoreSelectors';
+
+export interface Category {
+  id: number;
+  name: string;
+  value: string;
+}
+
+type Props = {
+  side: 'A' | 'B';
+  categories?: Category[];
+  className?: string;
+  hideWhenRequested?: boolean;
+  showHintText?: boolean;
+};
+
+const CHIP_BASE = 'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium';
+const CHIP_A = 'bg-green-50 text-green-600';
+const CHIP_B = 'bg-pink-50 text-pink-600';
+const HINT_TEXT = 'text-xs text-gray-400';
+
+const resolveCategory = (categoryId: number | null, categories?: Category[]) => {
+  if (categoryId == null || !categories) return { name: null, value: null };
+  const found = categories.find((c) => c.id === categoryId);
+  return { name: found?.name ?? null, value: found?.value ?? null };
+};
+
+const CompareCategoryNoticeChip: React.FC<Props> = ({
+  side,
+  categories,
+  className,
+  hideWhenRequested = true,
+  showHintText = true,
+}) => {
+  const requested = useCompareStore(selectRequested);
+  const inFlight = useCompareStore(selectInFlight);
+  const { id, categoryId } = useCompareStore(
+    useShallow(side === 'A' ? selectAForCategory : selectBForCategory),
+  );
+
+  if (hideWhenRequested && requested) return null;
+
+  /** 미선택 시: 자리만 확보(레이아웃 점프 방지) */
+  if (id == null) {
+    return <div className={className} aria-hidden />;
+  }
+
+  const { name, value } = resolveCategory(categoryId, categories);
+  const label = name ?? value ?? (categoryId != null ? `#${categoryId}` : '—');
+
+  const chipColor = side === 'A' ? CHIP_A : CHIP_B;
+
+  return (
+    <div
+      className={`flex items-center gap-2 ${className ?? ''}`}
+      aria-live='polite'
+      aria-atomic='true'
+      role='status'
+    >
+      {showHintText && label !== '—' && <span className={HINT_TEXT}>카테고리:</span>}
+      {inFlight ? (
+        <Skeleton className='h-[22px] w-16 rounded-full' />
+      ) : (
+        <span
+          className={`${CHIP_BASE} ${chipColor}`}
+          aria-label={`${side} 카테고리: ${label}`}
+          title={label}
+        >
+          <span className='sr-only uppercase'>{side}</span>
+          <span>{label}</span>
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default memo(CompareCategoryNoticeChip);

--- a/src/features/compare/components/CompareResult.tsx
+++ b/src/features/compare/components/CompareResult.tsx
@@ -1,6 +1,5 @@
 // 비교 결과 테이블, 비교 결과 문구 담는 컨테이너 컴포넌트
-// 역할: CompareResultTable, CompareResultSummary 포함,
-// api 가져오기
+// 역할: CompareResultTable, CompareResultSummary 포함, api 가져오기
 'use client';
 
 import { keepPreviousData } from '@tanstack/react-query';
@@ -16,11 +15,11 @@ import {
   selectRequested,
   selectRequestTick,
   selectCanCompare,
-} from '@/shared/stores/useCompareStoreSelectors'; // 표준 셀렉터 적용
+} from '@/shared/stores/useCompareStoreSelectors';
 
 import CompareResultSummary from './CompareResultSummary';
 import CompareResultTable from './CompareResultTable';
-import { useRetrieveProduct } from '../../../../openapi/queries'; // 코드젠으로 생성된 API 훅
+import { useRetrieveProduct } from '../../../../openapi/queries';
 import compareCalc from '../lib/compareCalc';
 import {
   METRIC_CONFIG,
@@ -30,8 +29,7 @@ import {
   decideWinner,
 } from '../types/compareTypes';
 
-import type { RetrieveProductDefaultResponse } from '../../../../openapi/queries/common'; //코드젠이 생성한 "원본 응답" 타입
-
+import type { RetrieveProductDefaultResponse } from '../../../../openapi/queries/common';
 /** ===============================================
  * 타입 정리
  * =============================================== */

--- a/src/shared/stores/useCompareStoreSelectors.ts
+++ b/src/shared/stores/useCompareStoreSelectors.ts
@@ -9,12 +9,80 @@ export const selectCanCompare = (state: CompareState) => state.canCompare();
 export const selectInvalidReason = (state: CompareState) => state.invalidReason();
 export const selectInFlight = (state: CompareState) => state.inFlight;
 
-/** 사용 팁
- * 셀렉터가 객체를 반환해야 할 때는 shallow를 꼭 함께 사용하세요.
- *  예시
- *  import { shallow } from 'zustand/shallow';
- *   const pair = useCompareStore(
- *   (state) => ({ a: state.a, b: state.b }),
- *   shallow,
- *   );
- */
+const isNumber = (v: unknown): v is number => typeof v === 'number' && !Number.isNaN(v);
+
+type CategoryMini = {
+  id: number | null;
+  categoryId: number | null;
+};
+
+export const selectAForCategory = (state: CompareState): CategoryMini => {
+  const a = state.a;
+  if (!a) {
+    return { id: null, categoryId: null };
+  }
+  return {
+    id: isNumber(a.id) ? a.id : null,
+    categoryId: isNumber(a.categoryId) ? a.categoryId : null,
+  };
+};
+
+export const selectBForCategory = (state: CompareState): CategoryMini => {
+  const b = state.b;
+  if (!b) {
+    return { id: null, categoryId: null };
+  }
+  return {
+    id: isNumber(b.id) ? b.id : null,
+    categoryId: isNumber(b.categoryId) ? b.categoryId : null,
+  };
+};
+
+/** 카테고리 정보 컴포넌트에서 한 번에 분기할 수 있게 요약된 페어 파생값 */
+export type CategoryPairSummary = {
+  aId: number | null;
+  bId: number | null;
+  aCategoryId: number | null;
+  bCategoryId: number | null;
+
+  hasA: boolean; // A 슬롯에 후보 존재?
+  hasB: boolean; // B 슬롯에 후보 존재?
+  hasAny: boolean; // 둘 중 하나라도 존재?
+  hasBoth: boolean; // 둘 다 존재?
+
+  sameCategory: boolean; // 양쪽 다 categoryId가 있고, 서로 같은가?
+  missingCategory: boolean; // 둘 중 하나라도 categoryId가 없는가?
+};
+
+export const selectCategoryPair = (state: CompareState): CategoryPairSummary => {
+  const a = state.a;
+  const b = state.b;
+
+  const aId = a && isNumber(a.id) ? a.id : null;
+  const bId = b && isNumber(b.id) ? b.id : null;
+
+  const aCategoryId = a && isNumber(a.categoryId) ? a.categoryId : null;
+  const bCategoryId = b && isNumber(b.categoryId) ? b.categoryId : null;
+
+  const hasA = aId !== null;
+  const hasB = bId !== null;
+  const hasAny = hasA || hasB;
+  const hasBoth = hasA && hasB;
+
+  const bothHaveCategory = isNumber(aCategoryId) && isNumber(bCategoryId);
+  const sameCategory = bothHaveCategory && aCategoryId === bCategoryId;
+  const missingCategory = !isNumber(aCategoryId) || !isNumber(bCategoryId);
+
+  return {
+    aId,
+    bId,
+    aCategoryId,
+    bCategoryId,
+    hasA,
+    hasB,
+    hasAny,
+    hasBoth,
+    sameCategory,
+    missingCategory,
+  };
+};


### PR DESCRIPTION
<!-- [티켓번호] 유형: 설명 상세하게 풀어서 쓰기 (이름) -->

<!-- 제목만 보고 변경 사항을 알 수 있게 풀어서 작성해주세요-->

## ✏️ 작업 내용 (📷 스크린샷•동영상)
![카테고리 정보 제공 칩 시연](https://github.com/user-attachments/assets/93e4a54a-de5e-4d95-b728-76544abae858)

- **비교하기 입력창에 콘텐츠 입력시, 해당 콘텐츠가 어떤 카테고리에 속해있는지 알 수 있는 작은 ui를 추가했습니다.**
- **해당 기능을 위해 CompareCategoryNoticeChip 컴포넌트를 추가했습니다.**
- **useCompareStoreSelectors에 새로운 컴포넌트용 상태를 추가했습니다.**
- **CompareResult의 주석을 조금 정리했습니다.**

<!-- 이번 PR에서 한 작업을 간략히 설명 -->
<!-- 스크린샷이나 동영상을 첨부한다면 되도록 before/after 형식으로 -->

## 📌 변경 범위
src/features/compare/components/CompareCategoryNoticeChip.tsx: 새로운 추가 ui용 컴포넌트
src/shared/stores/useCompareStoreSelectors.ts: 새로운 컴포넌트용 상태 추가
src/app/compare/page.tsx: 새로운 컴포넌트 배치
src/features/compare/components/CompareResult.tsx: 간단한 주석 정리
<!-- 영향 받는 서비스, 모듈, UI 등 -->

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

<!-- 리뷰어와 논의하고 싶은 부분 -->
