### PR TITLE
[HOY-200] fix: 성능 개선 (배혜민)

### DIFF
--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
 
 import ActivityCard from '@/features/mypage/components/activityCard';
 import ProfileCard from '@/features/mypage/components/ProfileCard';
-import ProfileTabsSection from '@/features/mypage/components/ProfileTabsSection';
 import { useFollowMutations } from '@/features/user/hooks/useFollowMutaion';
 import ProfilePageSkeleton from '@/shared/components/skeleton/PofilePageSkeleton';
 import { TEAM_ID, PATH_OPTION } from '@/shared/constants/constants';
@@ -21,6 +21,10 @@ import type {
 } from '../../../../openapi/queries/common';
 import type { ContentItem } from '@/shared/types/content';
 
+const ProfileTabsSection = dynamic(
+  () => import('@/features/mypage/components/ProfileTabsSection'),
+  { ssr: false, loading: () => null },
+);
 // 프로필 이미지가 없을 때 기본 이미지 반환
 const toSrc = (url?: string | null): string =>
   url && url.trim() !== '' ? url : '/images/ProfileFallbackImg.png';

--- a/src/features/mypage/components/ProfileCard.tsx
+++ b/src/features/mypage/components/ProfileCard.tsx
@@ -86,8 +86,10 @@ export default function ProfileCard({
         imgClassName={IMG_STYLE}
         src={avatarSrc}
         alt={name}
-        width={120}
-        height={120}
+        fill
+        sizes='(min-width:1280px) 180px, 120px'
+        priority
+        quality={80}
       />
 
       {/* 닉네임 / 소개글 */}


### PR DESCRIPTION
[HOY-200] fix: 성능 개선 (배혜민)

## ✏️ 작업 내용 (📷 스크린샷•동영상)

제 로컬에서 확인한 라이트하우스 성능 점수입니다 
<img width="509" height="329" alt="image" src="https://github.com/user-attachments/assets/ffcaebd7-f230-4bd5-b428-680b870f2c39" />

프로필 이미지 최적화와 불필요한 자바스크립트 정리 후 로컬에서 확인한 라이트하우스 성능 점수입니다 
<img width="379" height="333" alt="image" src="https://github.com/user-attachments/assets/143c97b1-8bcd-49b1-9d28-8684e0e0dddb" />

**ProfileTabs**
-SortDropdown을 모바일에서만 동적 로드
-데스크톱은 가벼운 버튼 UI로 대체
-React.memo 적용, clsx 제거
- dynamic import로 초기 JS 감소

**ProfileCard**
-sizes 적용: '(min-width:1280px) 180px, 120px'
-priority 사용 

/mypage, /user/[userId]
- dynamic import로 초기 JS 감소
- 사용하지 않는 자바스크립트 지우기

## 📌 변경 범위

src/app/mypage/page.tsx
src/app/user/[userId]/page.tsx
src/features/mypage/components/ProfileCard.tsx
src/features/mypage/components/ProfileTabs.tsx

## ✅ 체크리스트

- [x] pr요청시 lint + 빌드를 통과했습니다.
- [x] 코드가 스타일 가이드를 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 복잡/핵심 로직에 주석을 추가했습니다.
- [x] 관심사 분리를 확인했습니다.

## 🗨️ 논의 사항

베포 사이트에서는 80점대로 나오는데 제 컴퓨터가 문제인지 로컬에서하면 50점 밑으로 떨어지네요 ㅠㅠ 원래 다 그런가요 


[HOY-200]: https://team7advancedproject.atlassian.net/browse/HOY-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ